### PR TITLE
Fix long number parse in collections, and unify non-integral parse

### DIFF
--- a/johnzon-jaxrs/src/main/java/org/apache/johnzon/jaxrs/ConfigurableJohnzonProvider.java
+++ b/johnzon-jaxrs/src/main/java/org/apache/johnzon/jaxrs/ConfigurableJohnzonProvider.java
@@ -224,4 +224,8 @@ public class ConfigurableJohnzonProvider<T> implements MessageBodyWriter<T>, Mes
             throw new IllegalArgumentException(e.getCause());
         }
     }
+
+    public void setUseBigDecimalForFloats(final boolean useBigDecimalForFloats) {
+        builder.setUseBigDecimalForFloats(useBigDecimalForFloats);
+    }
 }

--- a/johnzon-jaxrs/src/main/java/org/apache/johnzon/jaxrs/WildcardConfigurableJohnzonProvider.java
+++ b/johnzon-jaxrs/src/main/java/org/apache/johnzon/jaxrs/WildcardConfigurableJohnzonProvider.java
@@ -219,4 +219,8 @@ public class WildcardConfigurableJohnzonProvider<T> implements MessageBodyWriter
     public void setPrimitiveConverters(final boolean val) {
         builder.setPrimitiveConverters(val);
     }
+
+    public void setUseBigDecimalForFloats(final boolean useBigDecimalForFloats) {
+        builder.setUseBigDecimalForFloats(useBigDecimalForFloats);
+    }
 }

--- a/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/JohnzonBuilder.java
+++ b/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/JohnzonBuilder.java
@@ -210,6 +210,9 @@ public class JohnzonBuilder implements JsonbBuilder {
         config.getProperty("johnzon.primitiveConverters")
                 .map(v -> !Boolean.class.isInstance(v) ? Boolean.parseBoolean(v.toString()) : Boolean.class.cast(v))
                 .ifPresent(builder::setPrimitiveConverters);
+        config.getProperty("johnzon.useBigDecimalForFloats")
+                .map(v -> !Boolean.class.isInstance(v) ? Boolean.parseBoolean(v.toString()) : Boolean.class.cast(v))
+                .ifPresent(builder::setUseBigDecimalForFloats);
 
         final Map<AdapterKey, Adapter<?, ?>> defaultConverters = createJava8Converters(builder);
 

--- a/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/DefaultMappingTest.java
+++ b/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/DefaultMappingTest.java
@@ -340,11 +340,11 @@ public class DefaultMappingTest {
         //Map
         Map<String, Object> map = (Map<String, Object>) JSONB.fromJson("{\"name\":\"unknown object\"}", Object.class);
 
-        //mapping for number  -> Integer, Long, BigDecimal
-        Map<String, Object> mapWithBigDecimal = (Map<String, Object>) JSONB.fromJson("{\"intValue\":5,\"longValue\":17179869184,\"otherValue\":1.2}", Object.class);
+        //mapping for number  -> Integer, Long, Double
+        Map<String, Object> mapWithBigDecimal = (Map<String, Object>) JSONB.fromJson("{\"intValue\":5,\"longValue\":17179869184,\"doubleValue\":1.2}", Object.class);
         assertTrue(mapWithBigDecimal.get("intValue") instanceof Integer);
         assertTrue(mapWithBigDecimal.get("longValue") instanceof Long);
-        assertTrue(mapWithBigDecimal.get("otherValue") instanceof BigDecimal);
+        assertTrue(mapWithBigDecimal.get("doubleValue") instanceof Double);
 
         //Collection
         /* why collection and not array or sthg else?

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MapperBuilder.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MapperBuilder.java
@@ -131,6 +131,7 @@ public class MapperBuilder {
     private boolean primitiveConverters;
     private boolean failOnUnknownProperties;
     private SerializeValueFilter serializeValueFilter;
+    private boolean useBigDecimalForFloats;
 
     public Mapper build() {
         if (readerFactory == null || generatorFactory == null) {
@@ -218,7 +219,7 @@ public class MapperBuilder {
                         skipNull, skipEmptyArray,
                         treatByteArrayAsBase64, treatByteArrayAsBase64URL, readAttributeBeforeWrite,
                         accessMode, encoding, attributeOrder, enforceQuoteString, failOnUnknownProperties,
-                        serializeValueFilter),
+                        serializeValueFilter, useBigDecimalForFloats),
                 closeables);
     }
 
@@ -400,6 +401,11 @@ public class MapperBuilder {
 
     public MapperBuilder setSerializeValueFilter(final SerializeValueFilter serializeValueFilter) {
         this.serializeValueFilter = serializeValueFilter;
+        return this;
+    }
+
+    public MapperBuilder setUseBigDecimalForFloats(final boolean useBigDecimalForFloats) {
+        this.useBigDecimalForFloats = useBigDecimalForFloats;
         return this;
     }
 }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MapperConfig.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MapperConfig.java
@@ -65,6 +65,7 @@ public /* DON'T MAKE IT HIDDEN */ class MapperConfig implements Cloneable {
     private final boolean enforceQuoteString;
     private final boolean failOnUnknown;
     private final SerializeValueFilter serializeValueFilter;
+    private final boolean useBigDecimalForFloats;
 
     private final Map<Class<?>, ObjectConverter.Writer<?>> objectConverterWriterCache;
     private final Map<Class<?>, ObjectConverter.Reader<?>> objectConverterReaderCache;
@@ -81,7 +82,7 @@ public /* DON'T MAKE IT HIDDEN */ class MapperConfig implements Cloneable {
                         final AccessMode accessMode, final Charset encoding,
                         final Comparator<String> attributeOrder,
                         final boolean enforceQuoteString, final boolean failOnUnknown,
-                        final SerializeValueFilter serializeValueFilter) {
+                        final SerializeValueFilter serializeValueFilter, boolean useBigDecimalForFloats) {
     //CHECKSTYLE:ON
         this.objectConverterWriters = objectConverterWriters;
         this.objectConverterReaders = objectConverterReaders;
@@ -102,6 +103,7 @@ public /* DON'T MAKE IT HIDDEN */ class MapperConfig implements Cloneable {
 
         this.objectConverterWriterCache = new HashMap<Class<?>, ObjectConverter.Writer<?>>(objectConverterWriters.size());
         this.objectConverterReaderCache = new HashMap<Class<?>, ObjectConverter.Reader<?>>(objectConverterReaders.size());
+        this.useBigDecimalForFloats = useBigDecimalForFloats;
     }
 
     public SerializeValueFilter getSerializeValueFilter() {
@@ -293,5 +295,9 @@ public /* DON'T MAKE IT HIDDEN */ class MapperConfig implements Cloneable {
 
     public boolean isEnforceQuoteString() {
         return enforceQuoteString;
+    }
+
+    public boolean isUseBigDecimalForFloats() {
+        return useBigDecimalForFloats;
     }
 }

--- a/johnzon-mapper/src/test/java/org/apache/johnzon/mapper/LiteralTest.java
+++ b/johnzon-mapper/src/test/java/org/apache/johnzon/mapper/LiteralTest.java
@@ -85,6 +85,16 @@ public class LiteralTest {
 
     }
 
+    @Test
+    public void readWhenUseBigDecimalForFloats() throws Exception {
+        final String json = "[1.5]";
+        final List<Object> expected = new ArrayList<Object>();
+        expected.add(new BigDecimal(1.5d));
+        final Collection<Object> read = new MapperBuilder().setUseBigDecimalForFloats(true).build()
+                .readCollection(new StringReader(json), new JohnzonParameterizedType(List.class, Object.class));
+        assertEquals(expected, read);
+    }
+
     @Test(expected = NumberFormatException.class)
     public void writeReadNumbersInf() {
         final NumberClass nc = new NumberClass();

--- a/johnzon-mapper/src/test/java/org/apache/johnzon/mapper/MapperConfigTest.java
+++ b/johnzon-mapper/src/test/java/org/apache/johnzon/mapper/MapperConfigTest.java
@@ -166,7 +166,7 @@ public class MapperConfigTest {
                                 new FieldAccessMode(true, true),
                                 Charset.forName("UTF-8"),
                                 null,
-                                false, false, null);
+                                false, false, null, false);
     }
 
 

--- a/johnzon-mapper/src/test/java/org/superbiz/ExtendMappingTest.java
+++ b/johnzon-mapper/src/test/java/org/superbiz/ExtendMappingTest.java
@@ -71,7 +71,7 @@ public class ExtendMappingTest {
                         public int compare(final String o1, final String o2) {
                             return o1.compareTo(o2);
                         }
-                    }, false, false, null));
+                    }, false, false, null, false));
         }
 
         @Override


### PR DESCRIPTION
On one code path non-integrals parsed as Double, on the other path
as BigDecimal.
Now it's always BigDecimal.