### PR TITLE
Add support for converting java.time.Instant to JSON string and vice versa

### DIFF
--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MapperBuilder.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MapperBuilder.java
@@ -56,6 +56,7 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -65,6 +66,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import org.apache.johnzon.mapper.converter.InstantConverter;
 
 // this class is responsible to hold any needed config
 // to build the runtime
@@ -74,6 +76,8 @@ public class MapperBuilder {
     static {
         //DEFAULT_CONVERTERS.put(Date.class, new DateConverter("yyyy-MM-dd'T'HH:mm:ssZ")); // ISO8601 long RFC822 zone
         DEFAULT_CONVERTERS.put(new AdapterKey(Date.class, String.class), new ConverterAdapter<Date>(new DateConverter("yyyyMMddHHmmssZ"))); // ISO8601 short
+        // ISO_OFFSET_DATE_TIME e.g. 2011-12-03T10:15:30+01:00
+        DEFAULT_CONVERTERS.put(new AdapterKey(Instant.class, String.class), new ConverterAdapter<Instant>(new InstantConverter())); 
         DEFAULT_CONVERTERS.put(new AdapterKey(URL.class, String.class), new ConverterAdapter<URL>(new URLConverter()));
         DEFAULT_CONVERTERS.put(new AdapterKey(URI.class, String.class), new ConverterAdapter<URI>(new URIConverter()));
         DEFAULT_CONVERTERS.put(new AdapterKey(Class.class, String.class), new ConverterAdapter<Class<?>>(new ClassConverter()));

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/InstantConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/InstantConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.johnzon.mapper.converter;
+
+import org.apache.johnzon.mapper.Converter;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+public class InstantConverter implements Converter<Instant> {
+
+    private final DateTimeFormatter formatterOut =  DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.systemDefault());
+    private final DateTimeFormatter formatterIn =  DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+    @Override
+    public String toString(final Instant instant) {
+        return formatterOut.format(instant);
+    }
+
+    @Override
+    public Instant fromString(final String text) {
+        try {
+            return Instant.from(formatterIn.parse(text));
+        } catch (final DateTimeParseException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/johnzon-mapper/src/test/java/org/apache/johnzon/mapper/converter/InstantConverterTest.java
+++ b/johnzon-mapper/src/test/java/org/apache/johnzon/mapper/converter/InstantConverterTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.johnzon.mapper.converter;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import org.apache.johnzon.mapper.MapperBuilder;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class InstantConverterTest {
+
+    @Test
+    public void convert() {
+        final Model model = new Model();
+        Instant testInstant = Instant.parse("2007-12-03T10:15:30.00Z");
+        model.setDate(testInstant);
+        String actual = new MapperBuilder().build().writeObjectAsString(model);
+        assertEquals(testInstant.getEpochSecond(), Model.class.cast(new MapperBuilder().build().readObject(actual, Model.class)).getDate().getEpochSecond());
+
+        InstantConverter ic = new InstantConverter();
+
+        testInstant = Instant.parse("2007-12-03T14:15:30.00Z");
+        DateTimeFormatter formatterOut =  DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.systemDefault());
+        String expectedJsonDateOut = formatterOut.format(testInstant);
+        
+        String jsonDateIn = "2007-12-03T17:15:30+03:00";
+        Instant convertedToInstant = ic.fromString(jsonDateIn);
+        assertEquals(testInstant, convertedToInstant);
+        String backToJsonDate = ic.toString(convertedToInstant);
+        assertEquals(expectedJsonDateOut, backToJsonDate);
+        
+        jsonDateIn = "2007-12-03T14:15:30.00+00:00";
+        convertedToInstant = ic.fromString(jsonDateIn);
+        assertEquals(testInstant, convertedToInstant);
+        backToJsonDate = ic.toString(convertedToInstant);
+        assertEquals(expectedJsonDateOut, backToJsonDate);
+        
+        jsonDateIn = "2007-12-03T14:15:30.00Z";
+        convertedToInstant = ic.fromString(jsonDateIn);
+        assertEquals(testInstant, convertedToInstant);
+        backToJsonDate = ic.toString(convertedToInstant);
+        assertEquals(expectedJsonDateOut, backToJsonDate);
+        
+        jsonDateIn = "2007-12-03T14:15:30.000Z";
+        convertedToInstant = ic.fromString(jsonDateIn);
+        assertEquals(testInstant, convertedToInstant);
+        backToJsonDate = ic.toString(convertedToInstant);
+        assertEquals(expectedJsonDateOut, backToJsonDate);
+        
+        jsonDateIn = "2007-12-03T08:15:30-06:00";
+        convertedToInstant = ic.fromString(jsonDateIn);
+        assertEquals(testInstant, convertedToInstant);
+        backToJsonDate = ic.toString(convertedToInstant);
+        assertEquals(expectedJsonDateOut, backToJsonDate);
+        
+
+    }
+
+    public static class Model {
+
+        private Instant date;
+
+        public Instant getDate() {
+            return date;
+        }
+
+        public void setDate(Instant date) {
+            this.date = date;
+        }
+    }
+}


### PR DESCRIPTION
Includes new converter with test cases.

Will parse JSON strings into an Instant so long as they are in a ISO_8601 date+time compliant format
e.g.:
2007-12-03T14:15:30.00Z
2007-12-03T17:15:30+03:00
2007-12-03T08:15:30-06:00
2007-12-03T08:15:30.000-06:00

Instant parsed to String will be in ISO_8601 format and have the local system timezone in the representation:
e.g. Say the system timezone is +02:00 and the Instant is 2007-12-03T14:15:30.00Z then the resulting String would be 2007-12-03T16:15:30+02:00