### PR TITLE
Rework of JSON-B Type Converters to use Mapper Converters and add Java8 Date/Time Converters to Mapper Project

### DIFF
--- a/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/JohnzonBuilder.java
+++ b/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/JohnzonBuilder.java
@@ -94,6 +94,21 @@ import static java.util.Collections.emptyMap;
 import static java.util.Optional.ofNullable;
 import static javax.json.bind.config.PropertyNamingStrategy.IDENTITY;
 import static javax.json.bind.config.PropertyOrderStrategy.LEXICOGRAPHICAL;
+import org.apache.johnzon.mapper.converter.CalendarConverter;
+import org.apache.johnzon.mapper.converter.DateConverter;
+import org.apache.johnzon.mapper.converter.DurationConverter;
+import org.apache.johnzon.mapper.converter.GregorianCalendarConverter;
+import org.apache.johnzon.mapper.converter.InstantConverter;
+import org.apache.johnzon.mapper.converter.LocalDateConverter;
+import org.apache.johnzon.mapper.converter.LocalDateTimeConverter;
+import org.apache.johnzon.mapper.converter.OffsetDateTimeConverter;
+import org.apache.johnzon.mapper.converter.OffsetTimeConverter;
+import org.apache.johnzon.mapper.converter.PeriodConverter;
+import org.apache.johnzon.mapper.converter.SimpleTimeZoneConverter;
+import org.apache.johnzon.mapper.converter.TimeZoneConverter;
+import org.apache.johnzon.mapper.converter.ZoneIdConverter;
+import org.apache.johnzon.mapper.converter.ZoneOffsetConverter;
+import org.apache.johnzon.mapper.converter.ZonedDateTimeConverter;
 
 public class JohnzonBuilder implements JsonbBuilder {
     private static final Object NO_BM = new Object();
@@ -439,186 +454,24 @@ public class JohnzonBuilder implements JsonbBuilder {
     private Map<AdapterKey, Adapter<?, ?>> createJava8Converters(final MapperBuilder builder) {
         final Map<AdapterKey, Adapter<?, ?>> converters = new HashMap<>();
 
-        final TimeZone timeZoneUTC = TimeZone.getTimeZone("UTC");
-        final ZoneId zoneIDUTC = ZoneId.of("UTC");
-
         // built-in converters not in mapper
-        converters.put(new AdapterKey(Period.class, String.class), new ConverterAdapter<>(new Converter<Period>() {
-            @Override
-            public String toString(final Period instance) {
-                return instance.toString();
-            }
-
-            @Override
-            public Period fromString(final String text) {
-                return Period.parse(text);
-            }
-        }));
-        converters.put(new AdapterKey(Duration.class, String.class), new ConverterAdapter<>(new Converter<Duration>() {
-            @Override
-            public String toString(final Duration instance) {
-                return instance.toString();
-            }
-
-            @Override
-            public Duration fromString(final String text) {
-                return Duration.parse(text);
-            }
-        }));
-        converters.put(new AdapterKey(Date.class, String.class), new ConverterAdapter<>(new Converter<Date>() {
-            @Override
-            public String toString(final Date instance) {
-                return LocalDateTime.ofInstant(instance.toInstant(), zoneIDUTC).toString();
-            }
-
-            @Override
-            public Date fromString(final String text) {
-                return Date.from(LocalDateTime.parse(text).toInstant(ZoneOffset.UTC));
-            }
-        }));
-        converters.put(new AdapterKey(Calendar.class, String.class), new ConverterAdapter<>(new Converter<Calendar>() {
-            @Override
-            public String toString(final Calendar instance) {
-                return ZonedDateTime.ofInstant(instance.toInstant(), zoneIDUTC).toString();
-            }
-
-            @Override
-            public Calendar fromString(final String text) {
-                final Calendar calendar = Calendar.getInstance();
-                calendar.setTimeZone(timeZoneUTC);
-                calendar.setTimeInMillis(ZonedDateTime.parse(text).toInstant().toEpochMilli());
-                return calendar;
-            }
-        }));
-        converters.put(new AdapterKey(GregorianCalendar.class, String.class), new ConverterAdapter<>(new Converter<GregorianCalendar>() {
-            @Override
-            public String toString(final GregorianCalendar instance) {
-                return instance.toZonedDateTime().toString();
-            }
-
-            @Override
-            public GregorianCalendar fromString(final String text) {
-                final GregorianCalendar calendar = new GregorianCalendar();
-                calendar.setTimeZone(timeZoneUTC);
-                calendar.setTimeInMillis(ZonedDateTime.parse(text).toInstant().toEpochMilli());
-                return calendar;
-            }
-        }));
-        converters.put(new AdapterKey(TimeZone.class, String.class), new ConverterAdapter<>(new Converter<TimeZone>() {
-            @Override
-            public String toString(final TimeZone instance) {
-                return instance.getID();
-            }
-
-            @Override
-            public TimeZone fromString(final String text) {
-                logIfDeprecatedTimeZone(text);
-                return TimeZone.getTimeZone(text);
-            }
-        }));
-        converters.put(new AdapterKey(ZoneId.class, String.class), new ConverterAdapter<>(new Converter<ZoneId>() {
-            @Override
-            public String toString(final ZoneId instance) {
-                return instance.getId();
-            }
-
-            @Override
-            public ZoneId fromString(final String text) {
-                return ZoneId.of(text);
-            }
-        }));
-        converters.put(new AdapterKey(ZoneOffset.class, String.class), new ConverterAdapter<>(new Converter<ZoneOffset>() {
-            @Override
-            public String toString(final ZoneOffset instance) {
-                return instance.getId();
-            }
-
-            @Override
-            public ZoneOffset fromString(final String text) {
-                return ZoneOffset.of(text);
-            }
-        }));
-        converters.put(new AdapterKey(SimpleTimeZone.class, String.class), new ConverterAdapter<>(new Converter<SimpleTimeZone>() {
-            @Override
-            public String toString(final SimpleTimeZone instance) {
-                return instance.getID();
-            }
-
-            @Override
-            public SimpleTimeZone fromString(final String text) {
-                logIfDeprecatedTimeZone(text);
-                final TimeZone timeZone = TimeZone.getTimeZone(text);
-                return new SimpleTimeZone(timeZone.getRawOffset(), timeZone.getID());
-            }
-        }));
-        converters.put(new AdapterKey(Instant.class, String.class), new ConverterAdapter<>(new Converter<Instant>() {
-            @Override
-            public String toString(final Instant instance) {
-                return instance.toString();
-            }
-
-            @Override
-            public Instant fromString(final String text) {
-                return Instant.parse(text);
-            }
-        }));
-        converters.put(new AdapterKey(LocalDate.class, String.class), new ConverterAdapter<>(new Converter<LocalDate>() {
-            @Override
-            public String toString(final LocalDate instance) {
-                return instance.toString();
-            }
-
-            @Override
-            public LocalDate fromString(final String text) {
-                return LocalDate.parse(text);
-            }
-        }));
-        converters.put(new AdapterKey(LocalDateTime.class, String.class), new ConverterAdapter<>(new Converter<LocalDateTime>() {
-            @Override
-            public String toString(final LocalDateTime instance) {
-                return instance.toString();
-            }
-
-            @Override
-            public LocalDateTime fromString(final String text) {
-                return LocalDateTime.parse(text);
-            }
-        }));
-        converters.put(new AdapterKey(ZonedDateTime.class, String.class), new ConverterAdapter<>(new Converter<ZonedDateTime>() {
-            @Override
-            public String toString(final ZonedDateTime instance) {
-                return instance.toString();
-            }
-
-            @Override
-            public ZonedDateTime fromString(final String text) {
-                return ZonedDateTime.parse(text);
-            }
-        }));
-        converters.put(new AdapterKey(OffsetDateTime.class, String.class), new ConverterAdapter<>(new Converter<OffsetDateTime>() {
-            @Override
-            public String toString(final OffsetDateTime instance) {
-                return instance.toString();
-            }
-
-            @Override
-            public OffsetDateTime fromString(final String text) {
-                return OffsetDateTime.parse(text);
-            }
-        }));
-        converters.put(new AdapterKey(OffsetTime.class, String.class), new ConverterAdapter<>(new Converter<OffsetTime>() {
-            @Override
-            public String toString(final OffsetTime instance) {
-                return instance.toString();
-            }
-
-            @Override
-            public OffsetTime fromString(final String text) {
-                return OffsetTime.parse(text);
-            }
-        }));
-        addDateFormatConfigConverters(converters, zoneIDUTC);
-
+        converters.put(new AdapterKey(Period.class, String.class), new ConverterAdapter<>(new PeriodConverter()));
+        converters.put(new AdapterKey(Duration.class, String.class), new ConverterAdapter<>(new DurationConverter()));
+        converters.put(new AdapterKey(Date.class, String.class), new ConverterAdapter<>(new DateConverter()));
+        converters.put(new AdapterKey(Calendar.class, String.class), new ConverterAdapter<>(new CalendarConverter()));
+        converters.put(new AdapterKey(GregorianCalendar.class, String.class), new ConverterAdapter<>(new GregorianCalendarConverter()));
+        converters.put(new AdapterKey(TimeZone.class, String.class), new ConverterAdapter<>(new TimeZoneConverter()));
+        converters.put(new AdapterKey(ZoneId.class, String.class), new ConverterAdapter<>(new ZoneIdConverter()));
+        converters.put(new AdapterKey(ZoneOffset.class, String.class), new ConverterAdapter<>(new ZoneOffsetConverter()));
+        converters.put(new AdapterKey(SimpleTimeZone.class, String.class), new ConverterAdapter<>(new SimpleTimeZoneConverter()));
+        converters.put(new AdapterKey(Instant.class, String.class), new ConverterAdapter<>(new InstantConverter()));
+        converters.put(new AdapterKey(LocalDate.class, String.class), new ConverterAdapter<>(new LocalDateConverter()));
+        converters.put(new AdapterKey(LocalDateTime.class, String.class), new ConverterAdapter<>(new LocalDateTimeConverter()));
+        converters.put(new AdapterKey(ZonedDateTime.class, String.class), new ConverterAdapter<>(new ZonedDateTimeConverter()));
+        converters.put(new AdapterKey(OffsetDateTime.class, String.class), new ConverterAdapter<>(new OffsetDateTimeConverter()));
+        converters.put(new AdapterKey(OffsetTime.class, String.class), new ConverterAdapter<>(new OffsetTimeConverter()));
+        
+        addDateFormatConfigConverters(converters, ZoneId.of("UTC"));
 
         converters.forEach((k, v) -> builder.addAdapter(k.getFrom(), k.getTo(), v));
         return converters;
@@ -714,14 +567,6 @@ public class JohnzonBuilder implements JsonbBuilder {
                 }
             }));
         });
-    }
-
-    private static void logIfDeprecatedTimeZone(final String text) {
-        /* TODO: get the list, UTC is clearly not deprecated but uses 3 letters
-        if (text.length() == 3) { // don't fail but log it
-            Logger.getLogger(JohnzonBuilder.class.getName()).severe("Deprecated timezone: " + text);
-        }
-        */
     }
 
     private Map<String, ?> generatorConfig() {

--- a/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/JsonbTypesTest.java
+++ b/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/JsonbTypesTest.java
@@ -61,7 +61,7 @@ public class JsonbTypesTest {
         final ZonedDateTime zonedDateTime = ZonedDateTime.of(localDateTime, ZoneId.of("UTC"));
         final String expected = "{" +
             "\"calendar\":\"" + zonedDateTime.toString() + "\"," +
-            "\"date\":\"" + localDateTime.toString() + "\"," +
+            "\"date\":\"" + "20150101010100Z" + "\"," + // PaulCB - Changed test to use Date format of Mapper yyyyMMddHHmmssZ to stay consistent
             "\"duration\":\"PT30S\"," +
             "\"gregorianCalendar\":\"" + zonedDateTime.toString() + "\"," +
             "\"instant\":\"" + Instant.ofEpochMilli(TimeUnit.DAYS.toMillis(localDate.toEpochDay())).toString() + "\"," +
@@ -82,6 +82,7 @@ public class JsonbTypesTest {
             "\"zoneOffset\":\"Z\"" +
             "}";
 
+        System.out.println(expected);
         final Jsonb jsonb = newJsonb();
 
         final Types types = jsonb.fromJson(new StringReader(expected), Types.class);

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MapperBuilder.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MapperBuilder.java
@@ -56,17 +56,43 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.SimpleTimeZone;
+import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import org.apache.johnzon.mapper.converter.CalendarConverter;
+import org.apache.johnzon.mapper.converter.DurationConverter;
+import org.apache.johnzon.mapper.converter.GregorianCalendarConverter;
 import org.apache.johnzon.mapper.converter.InstantConverter;
+import org.apache.johnzon.mapper.converter.LocalDateConverter;
+import org.apache.johnzon.mapper.converter.LocalDateTimeConverter;
+import org.apache.johnzon.mapper.converter.OffsetDateTimeConverter;
+import org.apache.johnzon.mapper.converter.OffsetTimeConverter;
+import org.apache.johnzon.mapper.converter.PeriodConverter;
+import org.apache.johnzon.mapper.converter.SimpleTimeZoneConverter;
+import org.apache.johnzon.mapper.converter.TimeZoneConverter;
+import org.apache.johnzon.mapper.converter.ZoneIdConverter;
+import org.apache.johnzon.mapper.converter.ZoneOffsetConverter;
+import org.apache.johnzon.mapper.converter.ZonedDateTimeConverter;
 
 // this class is responsible to hold any needed config
 // to build the runtime
@@ -74,16 +100,28 @@ public class MapperBuilder {
     private static final Map<AdapterKey, Adapter<?, ?>> DEFAULT_CONVERTERS = new HashMap<AdapterKey, Adapter<?, ?>>(24);
 
     static {
-        //DEFAULT_CONVERTERS.put(Date.class, new DateConverter("yyyy-MM-dd'T'HH:mm:ssZ")); // ISO8601 long RFC822 zone
-        DEFAULT_CONVERTERS.put(new AdapterKey(Date.class, String.class), new ConverterAdapter<Date>(new DateConverter("yyyyMMddHHmmssZ"))); // ISO8601 short
-        // ISO_OFFSET_DATE_TIME e.g. 2011-12-03T10:15:30+01:00
-        DEFAULT_CONVERTERS.put(new AdapterKey(Instant.class, String.class), new ConverterAdapter<Instant>(new InstantConverter())); 
-        DEFAULT_CONVERTERS.put(new AdapterKey(URL.class, String.class), new ConverterAdapter<URL>(new URLConverter()));
-        DEFAULT_CONVERTERS.put(new AdapterKey(URI.class, String.class), new ConverterAdapter<URI>(new URIConverter()));
-        DEFAULT_CONVERTERS.put(new AdapterKey(Class.class, String.class), new ConverterAdapter<Class<?>>(new ClassConverter()));
-        DEFAULT_CONVERTERS.put(new AdapterKey(String.class, String.class), new ConverterAdapter<String>(new StringConverter()));
-        DEFAULT_CONVERTERS.put(new AdapterKey(BigDecimal.class, String.class), new ConverterAdapter<BigDecimal>(new BigDecimalConverter()));
-        DEFAULT_CONVERTERS.put(new AdapterKey(BigInteger.class, String.class), new ConverterAdapter<BigInteger>(new BigIntegerConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(Date.class, String.class), new ConverterAdapter<>(new DateConverter())); 
+        DEFAULT_CONVERTERS.put(new AdapterKey(URL.class, String.class), new ConverterAdapter<>(new URLConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(URI.class, String.class), new ConverterAdapter<>(new URIConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(Class.class, String.class), new ConverterAdapter<>(new ClassConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(String.class, String.class), new ConverterAdapter<>(new StringConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(BigDecimal.class, String.class), new ConverterAdapter<>(new BigDecimalConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(BigInteger.class, String.class), new ConverterAdapter<>(new BigIntegerConverter()));
+        // Java 8 Date/Time Types
+        DEFAULT_CONVERTERS.put(new AdapterKey(Period.class, String.class), new ConverterAdapter<>(new PeriodConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(Duration.class, String.class), new ConverterAdapter<>(new DurationConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(Calendar.class, String.class), new ConverterAdapter<>(new CalendarConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(GregorianCalendar.class, String.class), new ConverterAdapter<>(new GregorianCalendarConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(Instant.class, String.class), new ConverterAdapter<>(new InstantConverter())); 
+        DEFAULT_CONVERTERS.put(new AdapterKey(TimeZone.class, String.class), new ConverterAdapter<>(new TimeZoneConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(ZoneId.class, String.class), new ConverterAdapter<>(new ZoneIdConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(ZoneOffset.class, String.class), new ConverterAdapter<>(new ZoneOffsetConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(SimpleTimeZone.class, String.class), new ConverterAdapter<>(new SimpleTimeZoneConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(LocalDate.class, String.class), new ConverterAdapter<>(new LocalDateConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(LocalDateTime.class, String.class), new ConverterAdapter<>(new LocalDateTimeConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(ZonedDateTime.class, String.class), new ConverterAdapter<>(new ZonedDateTimeConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(OffsetDateTime.class, String.class), new ConverterAdapter<>(new OffsetDateTimeConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(OffsetTime.class, String.class), new ConverterAdapter<>(new OffsetTimeConverter()));
         /* primitives should be hanlded low level and adapters will wrap them in string which is unlikely
         DEFAULT_CONVERTERS.put(new AdapterKey(Byte.class, String.class), new ConverterAdapter<Byte>(new CachedDelegateConverter<Byte>(new ByteConverter())));
         DEFAULT_CONVERTERS.put(new AdapterKey(Character.class, String.class), new ConverterAdapter<Character>(new CharacterConverter()));

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MapperBuilder.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MapperBuilder.java
@@ -56,6 +56,7 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -65,6 +66,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import org.apache.johnzon.mapper.converter.InstantConverter;
 
 // this class is responsible to hold any needed config
 // to build the runtime
@@ -74,6 +76,8 @@ public class MapperBuilder {
     static {
         //DEFAULT_CONVERTERS.put(Date.class, new DateConverter("yyyy-MM-dd'T'HH:mm:ssZ")); // ISO8601 long RFC822 zone
         DEFAULT_CONVERTERS.put(new AdapterKey(Date.class, String.class), new ConverterAdapter<Date>(new DateConverter("yyyyMMddHHmmssZ"))); // ISO8601 short
+        // ISO_OFFSET_DATE_TIME e.g. 2011-12-03T10:15:30+01:00
+        DEFAULT_CONVERTERS.put(new AdapterKey(Instant.class, String.class), new ConverterAdapter<Instant>(new InstantConverter())); 
         DEFAULT_CONVERTERS.put(new AdapterKey(URL.class, String.class), new ConverterAdapter<URL>(new URLConverter()));
         DEFAULT_CONVERTERS.put(new AdapterKey(URI.class, String.class), new ConverterAdapter<URI>(new URIConverter()));
         DEFAULT_CONVERTERS.put(new AdapterKey(Class.class, String.class), new ConverterAdapter<Class<?>>(new ClassConverter()));

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/CalendarConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/CalendarConverter.java
@@ -25,13 +25,13 @@ public class CalendarConverter extends Java8Converter<Calendar> {
 
     @Override
     public String toString(final Calendar instance) {
-        return ZonedDateTime.ofInstant(instance.toInstant(), zoneIDUTC).toString();
+        return ZonedDateTime.ofInstant(instance.toInstant(), ZONE_ID_UTC).toString();
     }
 
     @Override
     public Calendar fromString(final String text) {
         final Calendar calendar = Calendar.getInstance();
-        calendar.setTimeZone(timeZoneUTC);
+        calendar.setTimeZone(TIME_ZONE_UTC);
         calendar.setTimeInMillis(ZonedDateTime.parse(text).toInstant().toEpochMilli());
         return calendar;
     }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/CalendarConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/CalendarConverter.java
@@ -18,26 +18,21 @@
  */
 package org.apache.johnzon.mapper.converter;
 
-import org.apache.johnzon.mapper.Adapter;
-import org.apache.johnzon.mapper.internal.ConverterAdapter;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
 
-import java.util.Date;
+public class CalendarConverter extends Java8Converter<Calendar> {
 
-// needed for openjpa for instance which proxies dates
-public class DateWithCopyConverter implements Adapter<Date, String> {
-    private final Adapter<Date, String> delegate;
-
-    public DateWithCopyConverter(final Adapter<Date, String> delegate) {
-        this.delegate = delegate == null ? new ConverterAdapter<>(new DateConverter()) : delegate;
+    @Override
+    public String toString(final Calendar instance) {
+        return ZonedDateTime.ofInstant(instance.toInstant(), zoneIDUTC).toString();
     }
 
     @Override
-    public Date to(final String s) {
-        return delegate.to(s);
-    }
-
-    @Override
-    public String from(final Date date) {
-        return delegate.from(new Date(date.getTime()));
+    public Calendar fromString(final String text) {
+        final Calendar calendar = Calendar.getInstance();
+        calendar.setTimeZone(timeZoneUTC);
+        calendar.setTimeInMillis(ZonedDateTime.parse(text).toInstant().toEpochMilli());
+        return calendar;
     }
 }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/DateConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/DateConverter.java
@@ -24,18 +24,18 @@ import java.util.Date;
 
 public class DateConverter implements Converter<Date> {
 
-    private final InstantConverter instantConverter = new InstantConverter();
+    private static final InstantConverter INSTANT_CONVERTER = new InstantConverter();
     
-    @Override
+    @Override   
     public String toString(final Date instance) {
         // Johnzon has chosen to return Date in format yyyyMMddHHmmssZ
         // Use the ability of the Instant parser to recognise different date formats but return in the standard format ISO8601 short
-        String dt = instantConverter.toString(instance.toInstant());
+        String dt = INSTANT_CONVERTER.toString(instance.toInstant());
         return dt.replace(":", "").replace("-", "").replace("T", "");
     }
 
     @Override
     public Date fromString(final String text) {
-        return Date.from(instantConverter.fromString(text));
+        return Date.from(INSTANT_CONVERTER.fromString(text));
     }
 }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/DateConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/DateConverter.java
@@ -20,35 +20,22 @@ package org.apache.johnzon.mapper.converter;
 
 import org.apache.johnzon.mapper.Converter;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 
 public class DateConverter implements Converter<Date> {
-    // TODO: see if we can clean it
-    private final ThreadLocal<DateFormat> format;
 
-    public DateConverter(final String pattern) {
-        format = new ThreadLocal<DateFormat>() {
-            @Override
-            protected DateFormat initialValue() {
-                return new SimpleDateFormat(pattern);
-            }
-        };
-    }
-
+    private final InstantConverter instantConverter = new InstantConverter();
+    
     @Override
     public String toString(final Date instance) {
-        return format.get().format(instance);
+        // Johnzon has chosen to return Date in format yyyyMMddHHmmssZ
+        // Use the ability of the Instant parser to recognise different date formats but return in the standard format ISO8601 short
+        String dt = instantConverter.toString(instance.toInstant());
+        return dt.replace(":", "").replace("-", "").replace("T", "");
     }
 
     @Override
     public Date fromString(final String text) {
-        try {
-            return format.get().parse(text);
-        } catch (final ParseException e) {
-            throw new IllegalArgumentException(e);
-        }
+        return Date.from(instantConverter.fromString(text));
     }
 }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/DurationConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/DurationConverter.java
@@ -18,26 +18,17 @@
  */
 package org.apache.johnzon.mapper.converter;
 
-import org.apache.johnzon.mapper.Adapter;
-import org.apache.johnzon.mapper.internal.ConverterAdapter;
+import java.time.Duration;
 
-import java.util.Date;
+public class DurationConverter extends Java8Converter<Duration> {
 
-// needed for openjpa for instance which proxies dates
-public class DateWithCopyConverter implements Adapter<Date, String> {
-    private final Adapter<Date, String> delegate;
-
-    public DateWithCopyConverter(final Adapter<Date, String> delegate) {
-        this.delegate = delegate == null ? new ConverterAdapter<>(new DateConverter()) : delegate;
+    @Override
+    public String toString(final Duration instance) {
+        return instance.toString();
     }
 
     @Override
-    public Date to(final String s) {
-        return delegate.to(s);
-    }
-
-    @Override
-    public String from(final Date date) {
-        return delegate.from(new Date(date.getTime()));
+    public Duration fromString(final String text) {
+        return Duration.parse(text);
     }
 }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/GregorianCalendarConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/GregorianCalendarConverter.java
@@ -33,7 +33,7 @@ public class GregorianCalendarConverter extends Java8Converter<GregorianCalendar
     @Override
     public GregorianCalendar fromString(final String text) {
         final GregorianCalendar calendar = new GregorianCalendar();
-        calendar.setTimeZone(timeZoneUTC);
+        calendar.setTimeZone(TIME_ZONE_UTC);
         calendar.setTimeInMillis(ZonedDateTime.parse(text).toInstant().toEpochMilli());
         return calendar;
     }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/GregorianCalendarConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/GregorianCalendarConverter.java
@@ -18,26 +18,23 @@
  */
 package org.apache.johnzon.mapper.converter;
 
-import org.apache.johnzon.mapper.Adapter;
-import org.apache.johnzon.mapper.internal.ConverterAdapter;
+import java.time.ZonedDateTime;
+import java.util.GregorianCalendar;
 
-import java.util.Date;
+public class GregorianCalendarConverter extends Java8Converter<GregorianCalendar> {
 
-// needed for openjpa for instance which proxies dates
-public class DateWithCopyConverter implements Adapter<Date, String> {
-    private final Adapter<Date, String> delegate;
+    private final InstantConverter instantConverter = new InstantConverter();
 
-    public DateWithCopyConverter(final Adapter<Date, String> delegate) {
-        this.delegate = delegate == null ? new ConverterAdapter<>(new DateConverter()) : delegate;
+    @Override
+    public String toString(final GregorianCalendar instance) {
+        return instance.toZonedDateTime().toString();
     }
 
     @Override
-    public Date to(final String s) {
-        return delegate.to(s);
-    }
-
-    @Override
-    public String from(final Date date) {
-        return delegate.from(new Date(date.getTime()));
+    public GregorianCalendar fromString(final String text) {
+        final GregorianCalendar calendar = new GregorianCalendar();
+        calendar.setTimeZone(timeZoneUTC);
+        calendar.setTimeInMillis(ZonedDateTime.parse(text).toInstant().toEpochMilli());
+        return calendar;
     }
 }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/InstantConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/InstantConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.johnzon.mapper.converter;
+
+import org.apache.johnzon.mapper.Converter;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+public class InstantConverter implements Converter<Instant> {
+
+    private final DateTimeFormatter formatterOut =  DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.systemDefault());
+    private final DateTimeFormatter formatterIn =  DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+    @Override
+    public String toString(final Instant instant) {
+        return formatterOut.format(instant);
+    }
+
+    @Override
+    public Instant fromString(final String text) {
+        try {
+            return Instant.from(formatterIn.parse(text));
+        } catch (final DateTimeParseException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/InstantConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/InstantConverter.java
@@ -24,59 +24,59 @@ import java.time.format.DateTimeParseException;
 
 public class InstantConverter extends Java8Converter<Instant> {
 
-    private final DateTimeFormatter formatterOut = DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(zoneIDUTC);
+    private static final DateTimeFormatter FORMATTER_OUT = DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZONE_ID_UTC);
     // 2007-12-03T17:15:00+03:00
     // 2007-12-03T17:15:00.0+03:00
     // 2007-12-03T17:15:00.00+03:00
     // 2007-12-03T17:15:00.000+03:00
-    private final DateTimeFormatter formatterInISOLong = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+    private static final DateTimeFormatter FORMATTER_IN_ISO_LONG = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
     // 2007-12-03T14:15
-    private final DateTimeFormatter formatterInPattern1 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm").withZone(zoneIDUTC);
+    private static final DateTimeFormatter FORMATTER_IN_PATTERN_1 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm").withZone(ZONE_ID_UTC);
 
     //2007-12-03T17:15+03:00
-    private final DateTimeFormatter formatterInPattern2 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mmXXX");
+    private static final DateTimeFormatter FORMATTER_IN_PATTERN_2 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mmXXX");
 
     // 200712031415Z
     // 200712031115-0300
-    private final DateTimeFormatter formatterInPattern3 = DateTimeFormatter.ofPattern("yyyyMMddHHmmXX");
+    private static final DateTimeFormatter FORMATTER_IN_PATTERN_3 = DateTimeFormatter.ofPattern("yyyyMMddHHmmXX");
 
     // 20071203141500Z
     // 20071203111500-0300
-    private final DateTimeFormatter formatterInPattern4 = DateTimeFormatter.ofPattern("yyyyMMddHHmmssXX");
+    private static final DateTimeFormatter FORMATTER_IN_PATTERN_4 = DateTimeFormatter.ofPattern("yyyyMMddHHmmssXX");
 
     // 200712031415
-    private final DateTimeFormatter formatterInPattern5 = DateTimeFormatter.ofPattern("yyyyMMddHHmm").withZone(zoneIDUTC);
+    private static final DateTimeFormatter FORMATTER_IN_PATTERN_5 = DateTimeFormatter.ofPattern("yyyyMMddHHmm").withZone(ZONE_ID_UTC);
 
     // 20071203141500
-    private final DateTimeFormatter formatterInPattern6 = DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withZone(zoneIDUTC);
+    private static final DateTimeFormatter FORMATTER_IN_PATTERN_6 = DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withZone(ZONE_ID_UTC);
 
     // 2007-12-03T17:15:00+0300
-    private final DateTimeFormatter formatterInPattern7 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXX");
+    private static final DateTimeFormatter FORMATTER_IN_PATTERN_7 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXX");
 
     // 2007-12-03T17:15:00.0+0300
-    private final DateTimeFormatter formatterInPattern8 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SXX");
+    private static final DateTimeFormatter FORMATTER_IN_PATTERN_8 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SXX");
 
     // 2007-12-03T17:15:00.00+0300
-    private final DateTimeFormatter formatterInPattern9 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSXX");
+    private static final DateTimeFormatter FORMATTER_IN_PATTERN_9 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSXX");
 
     // 2007-12-03T17:15:00.000+0300
-    private final DateTimeFormatter formatterInPattern10 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXX");
+    private static final DateTimeFormatter FORMATTER_IN_PATTERN_10 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXX");
 
     //2007-12-03T14:15:00.000Z
-    private final DateTimeFormatter formatterInPattern11 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
+    private static final DateTimeFormatter FORMATTER_IN_PATTERN_11 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
 
     // 2007-12-03T17:15+0300
-    private final DateTimeFormatter formatterInPattern12 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mmXX");
+    private static final DateTimeFormatter FORMATTER_IN_PATTERN_12 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mmXX");
 
     // 20071203111500-03:00
-    private final DateTimeFormatter formatterInPattern13 = DateTimeFormatter.ofPattern("yyyyMMddHHmmssXXX");
+    private static final DateTimeFormatter FORMATTER_IN_PATTERN_13 = DateTimeFormatter.ofPattern("yyyyMMddHHmmssXXX");
 
     // 200712031115-03:00
-    private final DateTimeFormatter formatterInPattern14 = DateTimeFormatter.ofPattern("yyyyMMddHHmmXXX");
+    private static final DateTimeFormatter FORMATTER_IN_PATTERN_14 = DateTimeFormatter.ofPattern("yyyyMMddHHmmXXX");
     
     // 2007-12-03T14:15:00
-    private final DateTimeFormatter formatterInPattern15 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss").withZone(zoneIDUTC);
+    private static final DateTimeFormatter FORMATTER_IN_PATTERN_15 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss").withZone(ZONE_ID_UTC);
     
     
     /**
@@ -86,7 +86,7 @@ public class InstantConverter extends Java8Converter<Instant> {
      */
     @Override
     public String toString(final Instant instant) {
-        return formatterOut.format(instant);
+        return FORMATTER_OUT.format(instant);
     }
 
     /**
@@ -119,77 +119,77 @@ public class InstantConverter extends Java8Converter<Instant> {
                 switch (text.length()) {
                     case 16:
                         // 2007-12-03T14:15
-                        return Instant.from(formatterInPattern1.parse(text));
+                        return Instant.from(FORMATTER_IN_PATTERN_1.parse(text));
                     case 19:
                         // 2007-12-03T14:15:00
-                        return Instant.from(formatterInPattern15.parse(text));
+                        return Instant.from(FORMATTER_IN_PATTERN_15.parse(text));
                     case 21:
                         // 2007-12-03T17:15+0300
-                        return Instant.from(formatterInPattern12.parse(text));
+                        return Instant.from(FORMATTER_IN_PATTERN_12.parse(text));
                     case 22:
                         // 2007-12-03T17:15+03:00
-                        return Instant.from(formatterInPattern2.parse(text));
+                        return Instant.from(FORMATTER_IN_PATTERN_2.parse(text));
                     case 24:
                         if (text.endsWith("Z")) {
                             // 2007-12-03T14:15:00.000Z
-                            return Instant.from(formatterInPattern11.parse(text));
+                            return Instant.from(FORMATTER_IN_PATTERN_11.parse(text));
                         } else {
                             // 2007-12-03T17:15:00+0300
-                            return Instant.from(formatterInPattern7.parse(text));
+                            return Instant.from(FORMATTER_IN_PATTERN_7.parse(text));
                         }
                     case 26:
                         // 2007-12-03T17:15:00.0+0300
-                        return Instant.from(formatterInPattern8.parse(text));
+                        return Instant.from(FORMATTER_IN_PATTERN_8.parse(text));
                     case 27:
                         if (text.charAt(text.length() - 3) != ':') {
                             // 2007-12-03T17:15:00.00+0300
-                            return Instant.from(formatterInPattern9.parse(text));
+                            return Instant.from(FORMATTER_IN_PATTERN_9.parse(text));
                         } else {
-                            return Instant.from(formatterInISOLong.parse(text));
+                            return Instant.from(FORMATTER_IN_ISO_LONG.parse(text));
                         }
                     case 28:
                         if (text.charAt(text.length() - 3) != ':') {
                             // 2007-12-03T17:15:00.000+0300
-                            return Instant.from(formatterInPattern10.parse(text));
+                            return Instant.from(FORMATTER_IN_PATTERN_10.parse(text));
                         } else {
-                            return Instant.from(formatterInISOLong.parse(text));
+                            return Instant.from(FORMATTER_IN_ISO_LONG.parse(text));
                         }
                     default:
                         // Others can be picked up by ISO_OFFSET_DATE_TIME
-                        return Instant.from(formatterInISOLong.parse(text));
+                        return Instant.from(FORMATTER_IN_ISO_LONG.parse(text));
                 }
             } else if (text.endsWith("Z")) {
                 switch (text.length()) {
                     case 13:
                         // 200712031415Z
-                        return Instant.from(formatterInPattern3.parse(text));
+                        return Instant.from(FORMATTER_IN_PATTERN_3.parse(text));
                     default:
                         // 20071203141500Z
-                        return Instant.from(formatterInPattern4.parse(text));
+                        return Instant.from(FORMATTER_IN_PATTERN_4.parse(text));
                 }
             } else if (text.contains("-") || text.contains("+")) {
                 switch (text.length()) {
                     case 17:
                         // 200712031115-0300
-                        return Instant.from(formatterInPattern3.parse(text));
+                        return Instant.from(FORMATTER_IN_PATTERN_3.parse(text));
                     case 18:
                         // 200712031115-03:00
-                        return Instant.from(formatterInPattern14.parse(text));
+                        return Instant.from(FORMATTER_IN_PATTERN_14.parse(text));
                     case 20:
                         // 20071203111500-03:00
-                        return Instant.from(formatterInPattern13.parse(text));
+                        return Instant.from(FORMATTER_IN_PATTERN_13.parse(text));
                     default:
                         // 20071203111500-0300
-                        return Instant.from(formatterInPattern4.parse(text));
+                        return Instant.from(FORMATTER_IN_PATTERN_4.parse(text));
                 }
             } else {
                 switch (text.length()) {
                     case 12:
                         // 200712031415
-                        return Instant.from(formatterInPattern5.parse(text));
+                        return Instant.from(FORMATTER_IN_PATTERN_5.parse(text));
                     default:
                         // 20071203141500
-                        return Instant.from(formatterInPattern6.parse(text));
+                        return Instant.from(FORMATTER_IN_PATTERN_6.parse(text));
                 }
             }
         } catch (final DateTimeParseException e) {

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/InstantConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/InstantConverter.java
@@ -18,27 +18,180 @@
  */
 package org.apache.johnzon.mapper.converter;
 
-import org.apache.johnzon.mapper.Converter;
-
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
-public class InstantConverter implements Converter<Instant> {
+public class InstantConverter extends Java8Converter<Instant> {
 
-    private final DateTimeFormatter formatterOut =  DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.systemDefault());
-    private final DateTimeFormatter formatterIn =  DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+    private final DateTimeFormatter formatterOut = DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(zoneIDUTC);
+    // 2007-12-03T17:15:00+03:00
+    // 2007-12-03T17:15:00.0+03:00
+    // 2007-12-03T17:15:00.00+03:00
+    // 2007-12-03T17:15:00.000+03:00
+    private final DateTimeFormatter formatterInISOLong = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
+    // 2007-12-03T14:15
+    private final DateTimeFormatter formatterInPattern1 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm").withZone(zoneIDUTC);
+
+    //2007-12-03T17:15+03:00
+    private final DateTimeFormatter formatterInPattern2 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mmXXX");
+
+    // 200712031415Z
+    // 200712031115-0300
+    private final DateTimeFormatter formatterInPattern3 = DateTimeFormatter.ofPattern("yyyyMMddHHmmXX");
+
+    // 20071203141500Z
+    // 20071203111500-0300
+    private final DateTimeFormatter formatterInPattern4 = DateTimeFormatter.ofPattern("yyyyMMddHHmmssXX");
+
+    // 200712031415
+    private final DateTimeFormatter formatterInPattern5 = DateTimeFormatter.ofPattern("yyyyMMddHHmm").withZone(zoneIDUTC);
+
+    // 20071203141500
+    private final DateTimeFormatter formatterInPattern6 = DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withZone(zoneIDUTC);
+
+    // 2007-12-03T17:15:00+0300
+    private final DateTimeFormatter formatterInPattern7 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXX");
+
+    // 2007-12-03T17:15:00.0+0300
+    private final DateTimeFormatter formatterInPattern8 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SXX");
+
+    // 2007-12-03T17:15:00.00+0300
+    private final DateTimeFormatter formatterInPattern9 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSXX");
+
+    // 2007-12-03T17:15:00.000+0300
+    private final DateTimeFormatter formatterInPattern10 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXX");
+
+    //2007-12-03T14:15:00.000Z
+    private final DateTimeFormatter formatterInPattern11 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
+
+    // 2007-12-03T17:15+0300
+    private final DateTimeFormatter formatterInPattern12 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mmXX");
+
+    // 20071203111500-03:00
+    private final DateTimeFormatter formatterInPattern13 = DateTimeFormatter.ofPattern("yyyyMMddHHmmssXXX");
+
+    // 200712031115-03:00
+    private final DateTimeFormatter formatterInPattern14 = DateTimeFormatter.ofPattern("yyyyMMddHHmmXXX");
+    
+    // 2007-12-03T14:15:00
+    private final DateTimeFormatter formatterInPattern15 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss").withZone(zoneIDUTC);
+    
+    
+    /**
+     * Returns the Instant in format yyyy-MM-dd'T'HH:mm:ssZ
+     * @param instant
+     * @return String representation
+     */
     @Override
     public String toString(final Instant instant) {
         return formatterOut.format(instant);
     }
 
+    /**
+     * Parse string that could be in a number of different formats into an Instant.
+     * A missing time zone assumes UTC.
+     * Examples of what needs to be coped with (all are representing the same instant in time):
+     *
+     * 2007-12-03T17:15:00+03:00
+     * 2007-12-03T17:15:00.0+03:00
+     * 2007-12-03T17:15:00.00+03:00
+     * 2007-12-03T17:15:00.000+03:00
+     * 2007-12-03T17:15+03:00
+     * 2007-12-03T14:15
+     *
+     * 20071203141500Z
+     * 200712031415Z
+     *
+     * 20071203111500-0300
+     * 200712031115-0300
+     *
+     * 200712031415
+     * 20071203141500
+     * @param text
+     * @return Instant in time
+     */
     @Override
     public Instant fromString(final String text) {
         try {
-            return Instant.from(formatterIn.parse(text));
+            if (text.contains("T")) {
+                switch (text.length()) {
+                    case 16:
+                        // 2007-12-03T14:15
+                        return Instant.from(formatterInPattern1.parse(text));
+                    case 19:
+                        // 2007-12-03T14:15:00
+                        return Instant.from(formatterInPattern15.parse(text));
+                    case 21:
+                        // 2007-12-03T17:15+0300
+                        return Instant.from(formatterInPattern12.parse(text));
+                    case 22:
+                        // 2007-12-03T17:15+03:00
+                        return Instant.from(formatterInPattern2.parse(text));
+                    case 24:
+                        if (text.endsWith("Z")) {
+                            // 2007-12-03T14:15:00.000Z
+                            return Instant.from(formatterInPattern11.parse(text));
+                        } else {
+                            // 2007-12-03T17:15:00+0300
+                            return Instant.from(formatterInPattern7.parse(text));
+                        }
+                    case 26:
+                        // 2007-12-03T17:15:00.0+0300
+                        return Instant.from(formatterInPattern8.parse(text));
+                    case 27:
+                        if (text.charAt(text.length() - 3) != ':') {
+                            // 2007-12-03T17:15:00.00+0300
+                            return Instant.from(formatterInPattern9.parse(text));
+                        } else {
+                            return Instant.from(formatterInISOLong.parse(text));
+                        }
+                    case 28:
+                        if (text.charAt(text.length() - 3) != ':') {
+                            // 2007-12-03T17:15:00.000+0300
+                            return Instant.from(formatterInPattern10.parse(text));
+                        } else {
+                            return Instant.from(formatterInISOLong.parse(text));
+                        }
+                    default:
+                        // Others can be picked up by ISO_OFFSET_DATE_TIME
+                        return Instant.from(formatterInISOLong.parse(text));
+                }
+            } else if (text.endsWith("Z")) {
+                switch (text.length()) {
+                    case 13:
+                        // 200712031415Z
+                        return Instant.from(formatterInPattern3.parse(text));
+                    default:
+                        // 20071203141500Z
+                        return Instant.from(formatterInPattern4.parse(text));
+                }
+            } else if (text.contains("-") || text.contains("+")) {
+                switch (text.length()) {
+                    case 17:
+                        // 200712031115-0300
+                        return Instant.from(formatterInPattern3.parse(text));
+                    case 18:
+                        // 200712031115-03:00
+                        return Instant.from(formatterInPattern14.parse(text));
+                    case 20:
+                        // 20071203111500-03:00
+                        return Instant.from(formatterInPattern13.parse(text));
+                    default:
+                        // 20071203111500-0300
+                        return Instant.from(formatterInPattern4.parse(text));
+                }
+            } else {
+                switch (text.length()) {
+                    case 12:
+                        // 200712031415
+                        return Instant.from(formatterInPattern5.parse(text));
+                    default:
+                        // 20071203141500
+                        return Instant.from(formatterInPattern6.parse(text));
+                }
+            }
         } catch (final DateTimeParseException e) {
             throw new IllegalArgumentException(e);
         }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/Java8Converter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/Java8Converter.java
@@ -18,26 +18,21 @@
  */
 package org.apache.johnzon.mapper.converter;
 
-import org.apache.johnzon.mapper.Adapter;
-import org.apache.johnzon.mapper.internal.ConverterAdapter;
 
-import java.util.Date;
+import java.time.ZoneId;
+import java.util.TimeZone;
+import org.apache.johnzon.mapper.Converter;
 
-// needed for openjpa for instance which proxies dates
-public class DateWithCopyConverter implements Adapter<Date, String> {
-    private final Adapter<Date, String> delegate;
+public abstract class Java8Converter<T> implements Converter<T> {
 
-    public DateWithCopyConverter(final Adapter<Date, String> delegate) {
-        this.delegate = delegate == null ? new ConverterAdapter<>(new DateConverter()) : delegate;
-    }
+    final TimeZone timeZoneUTC = TimeZone.getTimeZone("UTC");
+    final ZoneId zoneIDUTC = ZoneId.of("UTC");
 
-    @Override
-    public Date to(final String s) {
-        return delegate.to(s);
-    }
-
-    @Override
-    public String from(final Date date) {
-        return delegate.from(new Date(date.getTime()));
+    static void logIfDeprecatedTimeZone(final String text) {
+        /* TODO: get the list, UTC is clearly not deprecated but uses 3 letters
+        if (text.length() == 3) { // don't fail but log it
+            Logger.getLogger(JohnzonBuilder.class.getName()).severe("Deprecated timezone: " + text);
+        }
+        */
     }
 }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/Java8Converter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/Java8Converter.java
@@ -25,8 +25,8 @@ import org.apache.johnzon.mapper.Converter;
 
 public abstract class Java8Converter<T> implements Converter<T> {
 
-    final TimeZone timeZoneUTC = TimeZone.getTimeZone("UTC");
-    final ZoneId zoneIDUTC = ZoneId.of("UTC");
+    final static TimeZone TIME_ZONE_UTC = TimeZone.getTimeZone("UTC");
+    final static ZoneId ZONE_ID_UTC = ZoneId.of("UTC");
 
     static void logIfDeprecatedTimeZone(final String text) {
         /* TODO: get the list, UTC is clearly not deprecated but uses 3 letters

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/LocalDateConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/LocalDateConverter.java
@@ -18,26 +18,17 @@
  */
 package org.apache.johnzon.mapper.converter;
 
-import org.apache.johnzon.mapper.Adapter;
-import org.apache.johnzon.mapper.internal.ConverterAdapter;
+import java.time.LocalDate;
 
-import java.util.Date;
+public class LocalDateConverter extends Java8Converter<LocalDate> {
 
-// needed for openjpa for instance which proxies dates
-public class DateWithCopyConverter implements Adapter<Date, String> {
-    private final Adapter<Date, String> delegate;
-
-    public DateWithCopyConverter(final Adapter<Date, String> delegate) {
-        this.delegate = delegate == null ? new ConverterAdapter<>(new DateConverter()) : delegate;
+    @Override
+    public String toString(final LocalDate instance) {
+        return instance.toString();
     }
 
     @Override
-    public Date to(final String s) {
-        return delegate.to(s);
-    }
-
-    @Override
-    public String from(final Date date) {
-        return delegate.from(new Date(date.getTime()));
+    public LocalDate fromString(final String text) {
+        return LocalDate.parse(text);
     }
 }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/LocalDateTimeConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/LocalDateTimeConverter.java
@@ -18,26 +18,17 @@
  */
 package org.apache.johnzon.mapper.converter;
 
-import org.apache.johnzon.mapper.Adapter;
-import org.apache.johnzon.mapper.internal.ConverterAdapter;
+import java.time.LocalDateTime;
 
-import java.util.Date;
+public class LocalDateTimeConverter extends Java8Converter<LocalDateTime> {
 
-// needed for openjpa for instance which proxies dates
-public class DateWithCopyConverter implements Adapter<Date, String> {
-    private final Adapter<Date, String> delegate;
-
-    public DateWithCopyConverter(final Adapter<Date, String> delegate) {
-        this.delegate = delegate == null ? new ConverterAdapter<>(new DateConverter()) : delegate;
+    @Override
+    public String toString(final LocalDateTime instance) {
+        return instance.toString();
     }
 
     @Override
-    public Date to(final String s) {
-        return delegate.to(s);
-    }
-
-    @Override
-    public String from(final Date date) {
-        return delegate.from(new Date(date.getTime()));
+    public LocalDateTime fromString(final String text) {
+        return LocalDateTime.parse(text);
     }
 }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/OffsetDateTimeConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/OffsetDateTimeConverter.java
@@ -18,26 +18,17 @@
  */
 package org.apache.johnzon.mapper.converter;
 
-import org.apache.johnzon.mapper.Adapter;
-import org.apache.johnzon.mapper.internal.ConverterAdapter;
+import java.time.OffsetDateTime;
 
-import java.util.Date;
+public class OffsetDateTimeConverter extends Java8Converter<OffsetDateTime> {
 
-// needed for openjpa for instance which proxies dates
-public class DateWithCopyConverter implements Adapter<Date, String> {
-    private final Adapter<Date, String> delegate;
-
-    public DateWithCopyConverter(final Adapter<Date, String> delegate) {
-        this.delegate = delegate == null ? new ConverterAdapter<>(new DateConverter()) : delegate;
+    @Override
+    public String toString(final OffsetDateTime instance) {
+        return instance.toString();
     }
 
     @Override
-    public Date to(final String s) {
-        return delegate.to(s);
-    }
-
-    @Override
-    public String from(final Date date) {
-        return delegate.from(new Date(date.getTime()));
+    public OffsetDateTime fromString(final String text) {
+        return OffsetDateTime.parse(text);
     }
 }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/OffsetTimeConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/OffsetTimeConverter.java
@@ -18,26 +18,17 @@
  */
 package org.apache.johnzon.mapper.converter;
 
-import org.apache.johnzon.mapper.Adapter;
-import org.apache.johnzon.mapper.internal.ConverterAdapter;
+import java.time.OffsetTime;
 
-import java.util.Date;
+public class OffsetTimeConverter extends Java8Converter<OffsetTime> {
 
-// needed for openjpa for instance which proxies dates
-public class DateWithCopyConverter implements Adapter<Date, String> {
-    private final Adapter<Date, String> delegate;
-
-    public DateWithCopyConverter(final Adapter<Date, String> delegate) {
-        this.delegate = delegate == null ? new ConverterAdapter<>(new DateConverter()) : delegate;
+    @Override
+    public String toString(final OffsetTime instance) {
+        return instance.toString();
     }
 
     @Override
-    public Date to(final String s) {
-        return delegate.to(s);
-    }
-
-    @Override
-    public String from(final Date date) {
-        return delegate.from(new Date(date.getTime()));
+    public OffsetTime fromString(final String text) {
+        return OffsetTime.parse(text);
     }
 }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/PeriodConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/PeriodConverter.java
@@ -18,26 +18,17 @@
  */
 package org.apache.johnzon.mapper.converter;
 
-import org.apache.johnzon.mapper.Adapter;
-import org.apache.johnzon.mapper.internal.ConverterAdapter;
+import java.time.Period;
 
-import java.util.Date;
+public class PeriodConverter extends Java8Converter<Period> {
 
-// needed for openjpa for instance which proxies dates
-public class DateWithCopyConverter implements Adapter<Date, String> {
-    private final Adapter<Date, String> delegate;
-
-    public DateWithCopyConverter(final Adapter<Date, String> delegate) {
-        this.delegate = delegate == null ? new ConverterAdapter<>(new DateConverter()) : delegate;
+    @Override
+    public String toString(final Period instance) {
+        return instance.toString();
     }
 
     @Override
-    public Date to(final String s) {
-        return delegate.to(s);
-    }
-
-    @Override
-    public String from(final Date date) {
-        return delegate.from(new Date(date.getTime()));
+    public Period fromString(final String text) {
+        return Period.parse(text);
     }
 }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/SimpleTimeZoneConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/SimpleTimeZoneConverter.java
@@ -18,26 +18,20 @@
  */
 package org.apache.johnzon.mapper.converter;
 
-import org.apache.johnzon.mapper.Adapter;
-import org.apache.johnzon.mapper.internal.ConverterAdapter;
+import java.util.SimpleTimeZone;
+import java.util.TimeZone;
 
-import java.util.Date;
+public class SimpleTimeZoneConverter extends Java8Converter<SimpleTimeZone> {
 
-// needed for openjpa for instance which proxies dates
-public class DateWithCopyConverter implements Adapter<Date, String> {
-    private final Adapter<Date, String> delegate;
-
-    public DateWithCopyConverter(final Adapter<Date, String> delegate) {
-        this.delegate = delegate == null ? new ConverterAdapter<>(new DateConverter()) : delegate;
+    @Override
+    public String toString(final SimpleTimeZone instance) {
+        return instance.getID();
     }
 
     @Override
-    public Date to(final String s) {
-        return delegate.to(s);
-    }
-
-    @Override
-    public String from(final Date date) {
-        return delegate.from(new Date(date.getTime()));
+    public SimpleTimeZone fromString(final String text) {
+        logIfDeprecatedTimeZone(text);
+        final TimeZone timeZone = TimeZone.getTimeZone(text);
+        return new SimpleTimeZone(timeZone.getRawOffset(), timeZone.getID());
     }
 }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/TimeZoneConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/TimeZoneConverter.java
@@ -18,26 +18,19 @@
  */
 package org.apache.johnzon.mapper.converter;
 
-import org.apache.johnzon.mapper.Adapter;
-import org.apache.johnzon.mapper.internal.ConverterAdapter;
+import java.util.TimeZone;
 
-import java.util.Date;
+public class TimeZoneConverter extends Java8Converter<TimeZone> {
 
-// needed for openjpa for instance which proxies dates
-public class DateWithCopyConverter implements Adapter<Date, String> {
-    private final Adapter<Date, String> delegate;
-
-    public DateWithCopyConverter(final Adapter<Date, String> delegate) {
-        this.delegate = delegate == null ? new ConverterAdapter<>(new DateConverter()) : delegate;
+    @Override
+    public String toString(final TimeZone instance) {
+        return instance.getID();
     }
 
     @Override
-    public Date to(final String s) {
-        return delegate.to(s);
+    public TimeZone fromString(final String text) {
+        logIfDeprecatedTimeZone(text);
+        return TimeZone.getTimeZone(text);
     }
 
-    @Override
-    public String from(final Date date) {
-        return delegate.from(new Date(date.getTime()));
-    }
 }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/ZoneIdConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/ZoneIdConverter.java
@@ -18,26 +18,17 @@
  */
 package org.apache.johnzon.mapper.converter;
 
-import org.apache.johnzon.mapper.Adapter;
-import org.apache.johnzon.mapper.internal.ConverterAdapter;
+import java.time.ZoneId;
 
-import java.util.Date;
+public class ZoneIdConverter extends Java8Converter<ZoneId> {
 
-// needed for openjpa for instance which proxies dates
-public class DateWithCopyConverter implements Adapter<Date, String> {
-    private final Adapter<Date, String> delegate;
-
-    public DateWithCopyConverter(final Adapter<Date, String> delegate) {
-        this.delegate = delegate == null ? new ConverterAdapter<>(new DateConverter()) : delegate;
+    @Override
+    public String toString(final ZoneId instance) {
+        return instance.getId();
     }
 
     @Override
-    public Date to(final String s) {
-        return delegate.to(s);
-    }
-
-    @Override
-    public String from(final Date date) {
-        return delegate.from(new Date(date.getTime()));
+    public ZoneId fromString(final String text) {
+        return ZoneId.of(text);
     }
 }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/ZoneOffsetConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/ZoneOffsetConverter.java
@@ -18,26 +18,17 @@
  */
 package org.apache.johnzon.mapper.converter;
 
-import org.apache.johnzon.mapper.Adapter;
-import org.apache.johnzon.mapper.internal.ConverterAdapter;
+import java.time.ZoneOffset;
 
-import java.util.Date;
+public class ZoneOffsetConverter extends Java8Converter<ZoneOffset> {
 
-// needed for openjpa for instance which proxies dates
-public class DateWithCopyConverter implements Adapter<Date, String> {
-    private final Adapter<Date, String> delegate;
-
-    public DateWithCopyConverter(final Adapter<Date, String> delegate) {
-        this.delegate = delegate == null ? new ConverterAdapter<>(new DateConverter()) : delegate;
+    @Override
+    public String toString(final ZoneOffset instance) {
+        return instance.getId();
     }
 
     @Override
-    public Date to(final String s) {
-        return delegate.to(s);
-    }
-
-    @Override
-    public String from(final Date date) {
-        return delegate.from(new Date(date.getTime()));
+    public ZoneOffset fromString(final String text) {
+        return ZoneOffset.of(text);
     }
 }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/ZonedDateTimeConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/ZonedDateTimeConverter.java
@@ -18,26 +18,17 @@
  */
 package org.apache.johnzon.mapper.converter;
 
-import org.apache.johnzon.mapper.Adapter;
-import org.apache.johnzon.mapper.internal.ConverterAdapter;
+import java.time.ZonedDateTime;
 
-import java.util.Date;
+public class ZonedDateTimeConverter extends Java8Converter<ZonedDateTime> {
 
-// needed for openjpa for instance which proxies dates
-public class DateWithCopyConverter implements Adapter<Date, String> {
-    private final Adapter<Date, String> delegate;
-
-    public DateWithCopyConverter(final Adapter<Date, String> delegate) {
-        this.delegate = delegate == null ? new ConverterAdapter<>(new DateConverter()) : delegate;
+    @Override
+    public String toString(final ZonedDateTime instance) {
+        return instance.toString();
     }
 
     @Override
-    public Date to(final String s) {
-        return delegate.to(s);
-    }
-
-    @Override
-    public String from(final Date date) {
-        return delegate.from(new Date(date.getTime()));
+    public ZonedDateTime fromString(final String text) {
+        return ZonedDateTime.parse(text);
     }
 }

--- a/johnzon-mapper/src/test/java/org/apache/johnzon/mapper/converter/InstantConverterTest.java
+++ b/johnzon-mapper/src/test/java/org/apache/johnzon/mapper/converter/InstantConverterTest.java
@@ -31,48 +31,54 @@ public class InstantConverterTest {
     @Test
     public void convert() {
         final Model model = new Model();
-        Instant testInstant = Instant.parse("2007-12-03T10:15:30.00Z");
+        Instant testInstant = Instant.parse("2007-12-03T14:15:00.00Z");
         model.setDate(testInstant);
         String actual = new MapperBuilder().build().writeObjectAsString(model);
         assertEquals(testInstant.getEpochSecond(), Model.class.cast(new MapperBuilder().build().readObject(actual, Model.class)).getDate().getEpochSecond());
 
         InstantConverter ic = new InstantConverter();
 
-        testInstant = Instant.parse("2007-12-03T14:15:30.00Z");
-        DateTimeFormatter formatterOut =  DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.systemDefault());
+        testInstant = Instant.parse("2007-12-03T14:15:00.00Z");
+        DateTimeFormatter formatterOut = DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.of("UTC"));
         String expectedJsonDateOut = formatterOut.format(testInstant);
-        
-        String jsonDateIn = "2007-12-03T17:15:30+03:00";
+
+        testParse("2007-12-03T11:15:00-03:00", testInstant, expectedJsonDateOut);
+        testParse("2007-12-03T14:15:00Z", testInstant, expectedJsonDateOut);
+        testParse("2007-12-03T17:15:00+0300", testInstant, expectedJsonDateOut);
+        testParse("2007-12-03T17:15:00.0+03:00", testInstant, expectedJsonDateOut);
+        testParse("2007-12-03T17:15:00.0+0300", testInstant, expectedJsonDateOut);
+        testParse("2007-12-03T17:15:00.00+03:00", testInstant, expectedJsonDateOut);
+        testParse("2007-12-03T11:15:00.00-03:00", testInstant, expectedJsonDateOut);
+        testParse("2007-12-03T17:15:00.00+0300", testInstant, expectedJsonDateOut);
+        testParse("2007-12-03T17:15:00.000+03:00", testInstant, expectedJsonDateOut);
+        testParse("2007-12-03T17:15:00.000+0300", testInstant, expectedJsonDateOut);
+        testParse("2007-12-03T14:15:00.000+0000", testInstant, expectedJsonDateOut);
+        testParse("2007-12-03T14:15:00.000Z", testInstant, expectedJsonDateOut);
+        testParse("2007-12-03T17:15+03:00", testInstant, expectedJsonDateOut);
+        testParse("2007-12-03T17:15+0300", testInstant, expectedJsonDateOut);
+        testParse("2007-12-03T14:15:00", testInstant, expectedJsonDateOut);
+        testParse("2007-12-03T14:15Z", testInstant, expectedJsonDateOut);
+        testParse("2007-12-03T14:15", testInstant, expectedJsonDateOut);
+        testParse("20071203141500Z", testInstant, expectedJsonDateOut);
+        testParse("200712031415Z", testInstant, expectedJsonDateOut);
+        testParse("20071203111500-0300", testInstant, expectedJsonDateOut);
+        testParse("20071203171500+0300", testInstant, expectedJsonDateOut);
+        testParse("20071203111500-03:00", testInstant, expectedJsonDateOut);
+        testParse("20071203171500+03:00", testInstant, expectedJsonDateOut);
+        testParse("200712031115-0300", testInstant, expectedJsonDateOut);
+        testParse("200712031115-03:00", testInstant, expectedJsonDateOut);
+        testParse("200712031415", testInstant, expectedJsonDateOut);
+        testParse("20071203141500", testInstant, expectedJsonDateOut);
+
+    }
+    
+    private void testParse(String jsonDateIn, Instant testInstant, String expectedJsonDateOut) {
+        InstantConverter ic = new InstantConverter();
         Instant convertedToInstant = ic.fromString(jsonDateIn);
         assertEquals(testInstant, convertedToInstant);
         String backToJsonDate = ic.toString(convertedToInstant);
+        // System.out.println(backToJsonDate);
         assertEquals(expectedJsonDateOut, backToJsonDate);
-        
-        jsonDateIn = "2007-12-03T14:15:30.00+00:00";
-        convertedToInstant = ic.fromString(jsonDateIn);
-        assertEquals(testInstant, convertedToInstant);
-        backToJsonDate = ic.toString(convertedToInstant);
-        assertEquals(expectedJsonDateOut, backToJsonDate);
-        
-        jsonDateIn = "2007-12-03T14:15:30.00Z";
-        convertedToInstant = ic.fromString(jsonDateIn);
-        assertEquals(testInstant, convertedToInstant);
-        backToJsonDate = ic.toString(convertedToInstant);
-        assertEquals(expectedJsonDateOut, backToJsonDate);
-        
-        jsonDateIn = "2007-12-03T14:15:30.000Z";
-        convertedToInstant = ic.fromString(jsonDateIn);
-        assertEquals(testInstant, convertedToInstant);
-        backToJsonDate = ic.toString(convertedToInstant);
-        assertEquals(expectedJsonDateOut, backToJsonDate);
-        
-        jsonDateIn = "2007-12-03T08:15:30-06:00";
-        convertedToInstant = ic.fromString(jsonDateIn);
-        assertEquals(testInstant, convertedToInstant);
-        backToJsonDate = ic.toString(convertedToInstant);
-        assertEquals(expectedJsonDateOut, backToJsonDate);
-        
-
     }
 
     public static class Model {

--- a/johnzon-mapper/src/test/java/org/apache/johnzon/mapper/converter/InstantConverterTest.java
+++ b/johnzon-mapper/src/test/java/org/apache/johnzon/mapper/converter/InstantConverterTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.johnzon.mapper.converter;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import org.apache.johnzon.mapper.MapperBuilder;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class InstantConverterTest {
+
+    @Test
+    public void convert() {
+        final Model model = new Model();
+        Instant testInstant = Instant.parse("2007-12-03T10:15:30.00Z");
+        model.setDate(testInstant);
+        String actual = new MapperBuilder().build().writeObjectAsString(model);
+        assertEquals(testInstant.getEpochSecond(), Model.class.cast(new MapperBuilder().build().readObject(actual, Model.class)).getDate().getEpochSecond());
+
+        InstantConverter ic = new InstantConverter();
+
+        testInstant = Instant.parse("2007-12-03T14:15:30.00Z");
+        DateTimeFormatter formatterOut =  DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.systemDefault());
+        String expectedJsonDateOut = formatterOut.format(testInstant);
+        
+        String jsonDateIn = "2007-12-03T17:15:30+03:00";
+        Instant convertedToInstant = ic.fromString(jsonDateIn);
+        assertEquals(testInstant, convertedToInstant);
+        String backToJsonDate = ic.toString(convertedToInstant);
+        assertEquals(expectedJsonDateOut, backToJsonDate);
+        
+        jsonDateIn = "2007-12-03T14:15:30.00+00:00";
+        convertedToInstant = ic.fromString(jsonDateIn);
+        assertEquals(testInstant, convertedToInstant);
+        backToJsonDate = ic.toString(convertedToInstant);
+        assertEquals(expectedJsonDateOut, backToJsonDate);
+        
+        jsonDateIn = "2007-12-03T14:15:30.00Z";
+        convertedToInstant = ic.fromString(jsonDateIn);
+        assertEquals(testInstant, convertedToInstant);
+        backToJsonDate = ic.toString(convertedToInstant);
+        assertEquals(expectedJsonDateOut, backToJsonDate);
+        
+        jsonDateIn = "2007-12-03T14:15:30.000Z";
+        convertedToInstant = ic.fromString(jsonDateIn);
+        assertEquals(testInstant, convertedToInstant);
+        backToJsonDate = ic.toString(convertedToInstant);
+        assertEquals(expectedJsonDateOut, backToJsonDate);
+        
+        jsonDateIn = "2007-12-03T08:15:30-06:00";
+        convertedToInstant = ic.fromString(jsonDateIn);
+        assertEquals(testInstant, convertedToInstant);
+        backToJsonDate = ic.toString(convertedToInstant);
+        assertEquals(expectedJsonDateOut, backToJsonDate);
+        
+
+    }
+
+    public static class Model {
+
+        private Instant date;
+
+        public Instant getDate() {
+            return date;
+        }
+
+        public void setDate(Instant date) {
+            this.date = date;
+        }
+    }
+}


### PR DESCRIPTION
Includes new converters with test cases.

Will parse JSON strings into an Instant/Date so long as they are in a format that can be heuristically determined.
e.g. these are all includes in test cases:
2007-12-03T11:15:00-03:00
2007-12-03T14:15:00Z
2007-12-03T17:15:00+0300
2007-12-03T17:15:00.0+03:00
2007-12-03T17:15:00.0+0300
2007-12-03T17:15:00.00+03:00
2007-12-03T11:15:00.00-03:00
2007-12-03T17:15:00.00+0300
2007-12-03T17:15:00.000+03:00
2007-12-03T17:15:00.000+0300
2007-12-03T14:15:00.000+0000
2007-12-03T14:15:00.000Z
2007-12-03T17:15+03:00
2007-12-03T17:15+0300
2007-12-03T14:15:00
2007-12-03T14:15Z
2007-12-03T14:15
20071203141500Z
200712031415Z
20071203111500-0300
20071203171500+0300
20071203111500-03:00
20071203171500+03:00
200712031115-0300
200712031115-03:00
200712031415
20071203141500

Instant parsed to String will be in ISO_8601 format with UTC (Z) timezone.
Date parsed to String will be in format yyyyMMddHHmmssZ with UTC (Z) timezone so as to be backwards compatible.