### PR TITLE
deserialization of enum from deserializationContext (normally used inside jsonbDeserializers)

### DIFF
--- a/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/JohnzonBuilder.java
+++ b/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/JohnzonBuilder.java
@@ -92,9 +92,11 @@ import java.util.stream.Stream;
 import static java.time.format.DateTimeFormatter.ofPattern;
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
 import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MICRO_OF_SECOND;
 import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
 import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
 import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
 import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 import static java.time.temporal.ChronoField.YEAR;
 import java.time.temporal.TemporalAccessor;
@@ -776,8 +778,10 @@ public class JohnzonBuilder implements JsonbBuilder {
         int hour = parse.isSupported(HOUR_OF_DAY) ? parse.get(HOUR_OF_DAY) : 0;
         int minute = parse.isSupported(MINUTE_OF_HOUR) ? parse.get(MINUTE_OF_HOUR) : 0;
         int second = parse.isSupported(SECOND_OF_MINUTE) ? parse.get(SECOND_OF_MINUTE) : 0;
-        int millisecond = parse.isSupported(MILLI_OF_SECOND) ? parse.get(MILLI_OF_SECOND) : 0;
-        return ZonedDateTime.of(year, month, day, hour, minute, second, millisecond, zone);
+        int nanosecond = parse.isSupported(NANO_OF_SECOND) ? parse.get(NANO_OF_SECOND) : 
+                parse.isSupported(MICRO_OF_SECOND) ? parse.get(MICRO_OF_SECOND) * 1000 : 
+                parse.isSupported(MILLI_OF_SECOND) ? parse.get(MILLI_OF_SECOND) * 1000000 : 0;
+        return ZonedDateTime.of(year, month, day, hour, minute, second, nanosecond, zone);
     }
 
     private static void logIfDeprecatedTimeZone(final String text) {

--- a/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/JsonbAccessMode.java
+++ b/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/JsonbAccessMode.java
@@ -585,6 +585,8 @@ public class JsonbAccessMode implements AccessMode, Closeable {
         }
         final Type[] genericInterfaces = aClass.getGenericInterfaces();
         return Stream.of(genericInterfaces).filter(ParameterizedType.class::isInstance)
+                .filter(i -> ParameterizedType.class.cast(i).getRawType() instanceof Class)
+                .filter(i -> ParameterizedType.class.cast(i).getActualTypeArguments()[0] instanceof Class)
                 .filter(i -> Adapter.class.isAssignableFrom(Class.class.cast(ParameterizedType.class.cast(i).getRawType())))
                 .findFirst()
                 .map(pt -> payloadType.isAssignableFrom(Class.class.cast(ParameterizedType.class.cast(pt).getActualTypeArguments()[0])))

--- a/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/JsonbAccessMode.java
+++ b/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/JsonbAccessMode.java
@@ -96,6 +96,7 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
+import java.util.Objects;
 import static java.util.Optional.ofNullable;
 import static org.apache.johnzon.mapper.reflection.Converters.matches;
 
@@ -586,6 +587,7 @@ public class JsonbAccessMode implements AccessMode, Closeable {
         final Type[] genericInterfaces = aClass.getGenericInterfaces();
         return Stream.of(genericInterfaces).filter(ParameterizedType.class::isInstance)
                 .filter(i -> ParameterizedType.class.cast(i).getRawType() instanceof Class)
+                .filter(i -> Objects.nonNull(ParameterizedType.class.cast(i).getActualTypeArguments()) && ParameterizedType.class.cast(i).getActualTypeArguments().length>0)
                 .filter(i -> ParameterizedType.class.cast(i).getActualTypeArguments()[0] instanceof Class)
                 .filter(i -> Adapter.class.isAssignableFrom(Class.class.cast(ParameterizedType.class.cast(i).getRawType())))
                 .findFirst()

--- a/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/JohnzonDeserializationContextTest.java
+++ b/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/JohnzonDeserializationContextTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.johnzon.jsonb;
+
+import java.io.StringReader;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.json.Json;
+import javax.json.bind.serializer.DeserializationContext;
+import org.apache.johnzon.jsonb.serializer.JohnzonDeserializationContext;
+import org.apache.johnzon.mapper.Adapter;
+import org.apache.johnzon.mapper.MapperConfig;
+import org.apache.johnzon.mapper.MappingParser;
+import org.apache.johnzon.mapper.MappingParserImpl;
+import org.apache.johnzon.mapper.Mappings;
+import org.apache.johnzon.mapper.ObjectConverter;
+import org.apache.johnzon.mapper.SerializeValueFilter;
+import org.apache.johnzon.mapper.access.FieldAndMethodAccessMode;
+import org.apache.johnzon.mapper.converter.BigDecimalConverter;
+import org.apache.johnzon.mapper.converter.BigIntegerConverter;
+import org.apache.johnzon.mapper.converter.ClassConverter;
+import org.apache.johnzon.mapper.converter.LocaleConverter;
+import org.apache.johnzon.mapper.converter.StringConverter;
+import org.apache.johnzon.mapper.converter.URIConverter;
+import org.apache.johnzon.mapper.converter.URLConverter;
+import org.apache.johnzon.mapper.internal.AdapterKey;
+import org.apache.johnzon.mapper.internal.ConverterAdapter;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class JohnzonDeserializationContextTest {
+    
+    private static final Map<AdapterKey, Adapter<?, ?>> DEFAULT_CONVERTERS = new HashMap<AdapterKey, Adapter<?, ?>>(24);
+    private final int version = -1;
+    private boolean close;
+    private final boolean skipNull = true;
+    private boolean skipEmptyArray;
+    private boolean treatByteArrayAsBase64;
+    private boolean treatByteArrayAsBase64URL;
+    private boolean readAttributeBeforeWrite;
+    private boolean enforceQuoteString;
+    private final boolean supportHiddenAccess = true;
+    private final Comparator<String> attributeOrder = null;
+    private boolean supportConstructors;
+    private boolean useGetterForCollections;
+    private final FieldAndMethodAccessMode accessMode = new FieldAndMethodAccessMode(supportConstructors, supportHiddenAccess, useGetterForCollections);
+    private final Charset encoding = Charset.forName(System.getProperty("johnzon.mapper.encoding", "UTF-8"));
+    private boolean failOnUnknownProperties;
+    private SerializeValueFilter serializeValueFilter;
+    private boolean useBigDecimalForFloats;
+    private final Boolean deduplicateObjects = null;
+    private final DeserializationContext deserializationContext;
+   
+    static {
+        DEFAULT_CONVERTERS.put(new AdapterKey(URL.class, String.class), new ConverterAdapter<>(new URLConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(URI.class, String.class), new ConverterAdapter<>(new URIConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(Class.class, String.class), new ConverterAdapter<>(new ClassConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(String.class, String.class), new ConverterAdapter<>(new StringConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(BigDecimal.class, String.class), new ConverterAdapter<>(new BigDecimalConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(BigInteger.class, String.class), new ConverterAdapter<>(new BigIntegerConverter()));
+        DEFAULT_CONVERTERS.put(new AdapterKey(Locale.class, String.class), new LocaleConverter());
+    }
+    
+    public JohnzonDeserializationContextTest() {
+        
+        ConcurrentMap<AdapterKey, Adapter<?, ?>> adapters = new ConcurrentHashMap<>(DEFAULT_CONVERTERS);
+        Map<Class<?>, ObjectConverter.Reader<?>> objectConverterReaders = new HashMap<>();
+        Map<Class<?>, ObjectConverter.Writer<?>> objectConverterWriters = new HashMap<>();
+        
+        MapperConfig mapperConfig = new MapperConfig(
+                adapters, objectConverterWriters, objectConverterReaders,
+                version, close,
+                skipNull, skipEmptyArray,
+                treatByteArrayAsBase64, treatByteArrayAsBase64URL, readAttributeBeforeWrite,
+                accessMode, encoding, attributeOrder, enforceQuoteString, failOnUnknownProperties,
+                serializeValueFilter, useBigDecimalForFloats, deduplicateObjects);
+        
+        MappingParser mappingParserImpl = new MappingParserImpl(mapperConfig, new Mappings(mapperConfig), Json.createReader(new StringReader("")), false);
+        deserializationContext = new JohnzonDeserializationContext(mappingParserImpl);
+        
+    }      
+
+    @Test
+    public void deserialize() {
+        
+        Assert.assertEquals(TestEnum.ONE, deserializationContext.deserialize(TestEnum.class, Json.createParser(new StringReader("\"ONE\""))));
+        
+    }
+    
+    private enum TestEnum {
+    
+        ONE, TWO, THREE;
+        
+    }
+    
+}

--- a/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/JsonbTypesTest.java
+++ b/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/JsonbTypesTest.java
@@ -117,18 +117,23 @@ public class JsonbTypesTest {
         readAndWriteWithDateFormat(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ"), "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
         readAndWriteWithDateFormat(DateTimeFormatter.ofPattern("yyyyMMdd+HHmmssZ"), "yyyyMMdd+HHmmssZ");
         readAndWriteWithDateFormat(DateTimeFormatter.ofPattern("yyyy-MM-dd"), "yyyy-MM-dd");
+        readAndWriteWithDateFormat(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZ"), "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZ");
     }
     
     private void readAndWriteWithDateFormat(DateTimeFormatter dateTimeFormatter, String dateFormat) {
         final LocalDate localDate = LocalDate.of(2015, 1, 1);
-        final LocalDateTime localDateTime = LocalDateTime.of(2015, 1, 1, 1, 1);
+        final LocalDateTime localDateTime = LocalDateTime.of(2015, 1, 1, 1, 1, 1, 111111111);
         final ZonedDateTime zonedDateTime = ZonedDateTime.of(localDateTime, ZoneId.of("UTC"));
+        final Calendar instance = Calendar.getInstance();
+        instance.setTime(Date.from(zonedDateTime.toInstant()));
+        final Calendar gregorianCalendar = GregorianCalendar.getInstance();
+        gregorianCalendar.setTime(Date.from(zonedDateTime.toInstant()));
         final String expected = "{" +
-            "\"calendar\":\"" + dateTimeFormatter.format(zonedDateTime) + "\"," +
-            "\"date\":\"" + dateTimeFormatter.format(ZonedDateTime.ofInstant(localDateTime.toInstant(ZoneOffset.UTC), ZoneId.of("UTC"))) + "\"," +
-            "\"gregorianCalendar\":\"" + dateTimeFormatter.format(zonedDateTime) + "\"," +
-            "\"instant\":\"" + dateTimeFormatter.format(ZonedDateTime.ofInstant(Instant.ofEpochMilli(TimeUnit.DAYS.toMillis(localDate.toEpochDay())), ZoneId.of("UTC"))) + "\"," +
-            "\"localDate\":\"" + dateTimeFormatter.format(ZonedDateTime.ofInstant(Instant.ofEpochMilli(TimeUnit.DAYS.toMillis(localDate.toEpochDay())), ZoneId.of("UTC"))) + "\"," +
+            "\"calendar\":\"" + dateTimeFormatter.format(ZonedDateTime.ofInstant(instance.toInstant(), ZoneId.of("UTC"))) + "\"," +
+            "\"date\":\"" + dateTimeFormatter.format(ZonedDateTime.ofInstant(Date.from(zonedDateTime.toInstant()).toInstant(), ZoneId.of("UTC"))) + "\"," +
+            "\"gregorianCalendar\":\"" + dateTimeFormatter.format(ZonedDateTime.ofInstant(gregorianCalendar.toInstant(), ZoneId.of("UTC"))) + "\"," +
+            "\"instant\":\"" + dateTimeFormatter.format(ZonedDateTime.ofInstant(zonedDateTime.toInstant(), ZoneId.of("UTC"))) + "\"," +
+            "\"localDate\":\"" + dateTimeFormatter.format(ZonedDateTime.ofInstant(localDate.atStartOfDay().toInstant(ZoneOffset.UTC), ZoneId.of("UTC"))) + "\"," +
             "\"localDateTime\":\"" + dateTimeFormatter.format(ZonedDateTime.ofInstant(localDateTime.toInstant(ZoneOffset.UTC), ZoneId.of("UTC"))) + "\"," +
             "\"offsetDateTime\":\"" + dateTimeFormatter.format(ZonedDateTime.ofInstant(OffsetDateTime.of(localDateTime, ZoneOffset.UTC).toInstant(), ZoneId.of("UTC"))) + "\"" +
             "}";

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mapper.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mapper.java
@@ -140,7 +140,7 @@ public class Mapper implements Closeable {
     private boolean isDeduplicateObjects(Class<?> rootType) {
         Boolean dedup = config.isDeduplicateObjects();
         if (dedup == null) {
-            Mappings.TypeMapping classMapping = mappings.findOrCreateTypeMapping(rootType);
+            Mappings.TypeMapping classMapping = mappings.findOrCreateTypeMapping(rootType, mappings.getApplyObjectConverter(rootType));
             if (classMapping != null && MappingType.CLASSMAPPING.equals(classMapping.getType())) {
                 dedup = classMapping.as(ClassMapping.class).isDeduplicateObjects();
             }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mapper.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mapper.java
@@ -44,6 +44,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import static java.util.Arrays.asList;
+import org.apache.johnzon.mapper.Mappings.ClassMapping;
+import org.apache.johnzon.mapper.Mappings.MappingType;
 import static org.apache.johnzon.mapper.internal.Streams.noClose;
 
 public class Mapper implements Closeable {
@@ -138,9 +140,9 @@ public class Mapper implements Closeable {
     private boolean isDeduplicateObjects(Class<?> rootType) {
         Boolean dedup = config.isDeduplicateObjects();
         if (dedup == null) {
-            Mappings.ClassMapping classMapping = mappings.findOrCreateClassMapping(rootType);
-            if (classMapping != null) {
-                dedup = classMapping.isDeduplicateObjects();
+            Mappings.TypeMapping classMapping = mappings.findOrCreateTypeMapping(rootType);
+            if (classMapping != null && MappingType.CLASSMAPPING.equals(classMapping.getType())) {
+                dedup = ClassMapping.class.cast(classMapping).isDeduplicateObjects();
             }
         }
 

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mapper.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mapper.java
@@ -142,7 +142,7 @@ public class Mapper implements Closeable {
         if (dedup == null) {
             Mappings.TypeMapping classMapping = mappings.findOrCreateTypeMapping(rootType);
             if (classMapping != null && MappingType.CLASSMAPPING.equals(classMapping.getType())) {
-                dedup = ClassMapping.class.cast(classMapping).isDeduplicateObjects();
+                dedup = classMapping.as(ClassMapping.class).isDeduplicateObjects();
             }
         }
 

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MappingGeneratorImpl.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MappingGeneratorImpl.java
@@ -237,7 +237,7 @@ public class MappingGeneratorImpl implements MappingGenerator {
         }
 
         final Class<?> objectClass = object.getClass();
-        final Mappings.ClassMapping classMapping = mappings.findOrCreateClassMapping(objectClass);
+        final Mappings.TypeMapping classMapping = mappings.findOrCreateTypeMapping(objectClass);
         if (classMapping == null) {
             throw new MapperException("No mapping for " + objectClass.getName());
         }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MappingParserImpl.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MappingParserImpl.java
@@ -288,6 +288,12 @@ public class MappingParserImpl implements MappingParser {
                     }
                     
                 }
+            } else if (Map.class == type || HashMap.class == type || LinkedHashMap.class == type) {
+                final LinkedHashMap<String, Object> map = new LinkedHashMap<String, Object>();
+                for (final Map.Entry<String, JsonValue> value : object.entrySet()) {
+                    map.put(value.getKey(), toObject(null, value.getValue(), Object.class, null, jsonPointer, Object.class));
+                }
+                return map;
             } else if (TypeVariable.class.isInstance(type)) {
                 
                 // if a specific mapping has not been declared, let's try finding and using bounds
@@ -302,12 +308,6 @@ public class MappingParserImpl implements MappingParser {
                     }
                 }
 
-            } else if (Map.class == type || HashMap.class == type || LinkedHashMap.class == type) {
-                final LinkedHashMap<String, Object> map = new LinkedHashMap<String, Object>();
-                for (final Map.Entry<String, JsonValue> value : object.entrySet()) {
-                    map.put(value.getKey(), toObject(null, value.getValue(), Object.class, null, jsonPointer, Object.class));
-                }
-                return map;
             }
         }
         if (classMapping == null) {

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MappingParserImpl.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MappingParserImpl.java
@@ -229,7 +229,7 @@ public class MappingParserImpl implements MappingParser {
             }
         }
 
-        final Mappings.TypeMapping typeMapping = mappings.findOrCreateTypeMapping(type);
+        final Mappings.TypeMapping typeMapping = mappings.findOrCreateTypeMapping(type, applyObjectConverter);
 
         if (typeMapping == null) {
             if (ParameterizedType.class.isInstance(type)) {

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MappingParserImpl.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MappingParserImpl.java
@@ -700,7 +700,7 @@ public class MappingParserImpl implements MappingParser {
         return collection;
     }
 
-    
+
     private Object[] createParameters(final Mappings.ClassMapping mapping, final JsonObject object, JsonPointerTracker jsonPointer) {
         final int length = mapping.factory.getParameterTypes().length;
         final Object[] objects = new Object[length];

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MappingParserImpl.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MappingParserImpl.java
@@ -321,7 +321,7 @@ public class MappingParserImpl implements MappingParser {
         if (classMapping.adapter != null) {
             return classMapping.adapter.from(t);
         }
-         */
+        */
 
         if (classMapping.factory == null) {
             throw new MapperException(classMapping.clazz + " not instantiable");
@@ -330,7 +330,7 @@ public class MappingParserImpl implements MappingParser {
         if (config.isFailOnUnknown()) {
             if (!classMapping.setters.keySet().containsAll(object.keySet())) {
                 throw new MapperException("(fail on unknown properties): " + new HashSet<String>(object.keySet()) {{
-                        removeAll(classMapping.setters.keySet());
+                    removeAll(classMapping.setters.keySet());
                 }});
                     }
             }
@@ -501,8 +501,8 @@ public class MappingParserImpl implements MappingParser {
 
 
     private Object toObject(final Object baseInstance, final JsonValue jsonValue,
-            final Type type, final Adapter itemConverter, final JsonPointerTracker jsonPointer,
-            final Type rootType) {
+                            final Type type, final Adapter itemConverter, final JsonPointerTracker jsonPointer,
+                            final Type rootType) {
         if (jsonValue == null || JsonValue.NULL.equals(jsonValue)) {
             return null;
         }
@@ -618,8 +618,8 @@ public class MappingParserImpl implements MappingParser {
     }
 
     private Object buildArray(final Type type, final JsonArray jsonArray, final Adapter itemConverter,
-            final ObjectConverter.Reader objectConverter,
-            final JsonPointerTracker jsonPointer, final Type rootType) {
+                              final ObjectConverter.Reader objectConverter,
+                              final JsonPointerTracker jsonPointer, final Type rootType) {
         if (Class.class.isInstance(type)) {
             final Class clazz = Class.class.cast(type);
             if (clazz.isArray()) {
@@ -643,7 +643,7 @@ public class MappingParserImpl implements MappingParser {
     }
 
     private Object buildArrayWithComponentType(final JsonArray jsonArray, final Class<?> componentType, final Adapter itemConverter,
-            final JsonPointerTracker jsonPointer, final Type rootType) {
+                                               final JsonPointerTracker jsonPointer, final Type rootType) {
         final Object array = Array.newInstance(componentType, jsonArray.size());
         int i = 0;
         for (final JsonValue value : jsonArray) {
@@ -655,8 +655,8 @@ public class MappingParserImpl implements MappingParser {
     }
 
     private <T> Collection<T> mapCollection(final Mappings.CollectionMapping mapping, final JsonArray jsonArray,
-            final Adapter itemConverter, ObjectConverter.Reader objectConverter,
-            final JsonPointerTracker jsonPointer, final Type rootType) {
+                                            final Adapter itemConverter, ObjectConverter.Reader objectConverter,
+                                            final JsonPointerTracker jsonPointer, final Type rootType) {
         final Collection collection;
 
         if (SortedSet.class == mapping.raw || NavigableSet.class == mapping.raw || TreeSet.class == mapping.raw) {
@@ -682,7 +682,7 @@ public class MappingParserImpl implements MappingParser {
             collection.add(JsonValue.NULL.equals(value)
                     ? null
                     : toValue(null, value, null, itemConverter, mapping.arg, objectConverter,
-                            isDeduplicateObjects ? new JsonPointerTracker(jsonPointer, i) : null, rootType));
+                    isDeduplicateObjects ? new JsonPointerTracker(jsonPointer, i) : null, rootType));
             i++;
         }
 
@@ -700,6 +700,7 @@ public class MappingParserImpl implements MappingParser {
         return collection;
     }
 
+    
     private Object[] createParameters(final Mappings.ClassMapping mapping, final JsonObject object, JsonPointerTracker jsonPointer) {
         final int length = mapping.factory.getParameterTypes().length;
         final Object[] objects = new Object[length];
@@ -721,8 +722,8 @@ public class MappingParserImpl implements MappingParser {
     }
 
     private Object toValue(final Object baseInstance, final JsonValue jsonValue, final Adapter converter,
-            final Adapter itemConverter, final Type type, final ObjectConverter.Reader objectConverter,
-            final JsonPointerTracker jsonPointer, final Type rootType) {
+                           final Adapter itemConverter, final Type type, final ObjectConverter.Reader objectConverter,
+                           final JsonPointerTracker jsonPointer, final Type rootType) {
 
         if (objectConverter != null) {
 

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mappings.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mappings.java
@@ -65,9 +65,9 @@ public class Mappings {
         public final AccessMode.Factory factory;
         public final Map<String, Getter> getters;
         public final Map<String, Setter> setters;
+        public final Adapter adapter;
         public final ObjectConverter.Reader reader;
         public final ObjectConverter.Writer writer;
-        public final Adapter adapter;
         public final Getter anyGetter;
         public final Method anySetter;
         
@@ -90,9 +90,9 @@ public class Mappings {
         public <T extends TypeMapping> T as(Class<T> type){
             return type.cast(this);
         }
-        
+
     }
-    
+
     public static class CollectionMapping {
         public final Class<?> raw;
         public final Type arg;
@@ -304,7 +304,7 @@ public class Mappings {
         return null;
     }
 
-    // has JSon API a method for this annotatedType
+    // has JSon API a method for this type
     public static boolean isPrimitive(final Type type) {
         if (type == String.class) {
             return true;

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mappings.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mappings.java
@@ -289,6 +289,10 @@ public class Mappings {
         this.config = config;
     }
 
+    public Boolean getApplyObjectConverter(Type targetType){
+        return targetType instanceof Class || targetType instanceof ParameterizedType || targetType instanceof TypeVariable;
+    }
+    
     public CollectionMapping findCollectionMapping(final ParameterizedType genericType, final Type enclosingType) {
         CollectionMapping collectionMapping = collections.get(genericType);
         if (collectionMapping == null) {

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mappings.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mappings.java
@@ -92,6 +92,10 @@ public class Mappings {
             this.anySetter = anySetter;
         }
         
+        public <T extends TypeMapping> T as(Class<T> type){
+            return type.cast(this);
+        } 
+        
         public abstract MappingType getType();
     }
     

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mappings.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mappings.java
@@ -60,11 +60,7 @@ import static org.apache.johnzon.mapper.reflection.Generics.resolve;
 
 public class Mappings {
     
-    public enum MappingType {
-        CLASSMAPPING;
-    }
-    
-    public abstract static class TypeMapping {
+    public static class TypeMapping {
         public final Type type;
         public final AccessMode.Factory factory;
         public final Map<String, Getter> getters;
@@ -93,40 +89,8 @@ public class Mappings {
         
         public <T extends TypeMapping> T as(Class<T> type){
             return type.cast(this);
-        } 
+        }
         
-        public abstract MappingType getType();
-    }
-    
-    public static class ClassMapping extends TypeMapping {
-
-        private Boolean deduplicateObjects;
-        private boolean deduplicationEvaluated = false;
-
-        protected ClassMapping(final Type type, final AccessMode.Factory factory,
-                               final Map<String, Getter> getters, final Map<String, Setter> setters,
-                               final Adapter<?, ?> adapter,
-                               final ObjectConverter.Reader<?> reader, final ObjectConverter.Writer<?> writer,
-                               final Getter anyGetter, final Method anySetter) {
-            super(type, factory, getters, setters, adapter, reader, writer, anyGetter, anySetter);
-        }
-
-        public Boolean isDeduplicateObjects() {
-            if (!deduplicationEvaluated) {
-                JohnzonDeduplicateObjects jdo = ((Class<JohnzonDeduplicateObjects>) type).getAnnotation(JohnzonDeduplicateObjects.class);
-                if (jdo != null){
-                    deduplicateObjects = jdo.value();
-                }
-                deduplicationEvaluated = true;
-            }
-            return deduplicateObjects;
-        }
-
-        @Override
-        public MappingType getType() {
-            return MappingType.CLASSMAPPING;
-        }
-
     }
     
     public static class CollectionMapping {
@@ -457,7 +421,7 @@ public class Mappings {
         reader = applyObjectConverter && Objects.nonNull(reader)  ? reader : accessMode.findReader(clazz);
         writer = applyObjectConverter && Objects.nonNull(writer)  ? writer : accessMode.findWriter(clazz);
         
-        final TypeMapping mapping = new ClassMapping(
+        final TypeMapping mapping = new TypeMapping(
                 type, accessMode.findFactory(clazz), getters, setters,
                 adapter,
                 reader,

--- a/johnzon-mapper/src/test/java/org/apache/johnzon/mapper/ObjectTypeTest.java
+++ b/johnzon-mapper/src/test/java/org/apache/johnzon/mapper/ObjectTypeTest.java
@@ -53,7 +53,7 @@ public class ObjectTypeTest {
     }
 
 
-//    @Test
+    @Test
     public void testObjectConverterMapper() {
         Mapper mapper = new MapperBuilder()
                 .setAccessModeName(accessMode)

--- a/johnzon-mapper/src/test/java/org/apache/johnzon/mapper/ObjectTypeTest.java
+++ b/johnzon-mapper/src/test/java/org/apache/johnzon/mapper/ObjectTypeTest.java
@@ -53,7 +53,7 @@ public class ObjectTypeTest {
     }
 
 
-    @Test
+//    @Test
     public void testObjectConverterMapper() {
         Mapper mapper = new MapperBuilder()
                 .setAccessModeName(accessMode)

--- a/johnzon-mapper/src/test/java/org/superbiz/ExtendMappingTest.java
+++ b/johnzon-mapper/src/test/java/org/superbiz/ExtendMappingTest.java
@@ -45,7 +45,7 @@ public class ExtendMappingTest {
     @Test // strictly speaking compilation checked 50% of the test
     public void run() {
         final MyMappings myMappings = new MyMappings();
-        final Mappings.ClassMapping model = myMappings.findOrCreateClassMapping(MyModel.class);
+        final Mappings.TypeMapping model = myMappings.findOrCreateTypeMapping(MyModel.class);
         assertTrue(myMappings.classes().isEmpty());
         assertEquals(1, model.getters.size());
         assertEquals(1, model.setters.size());
@@ -75,8 +75,8 @@ public class ExtendMappingTest {
         }
 
         @Override
-        public ClassMapping findOrCreateClassMapping(final Type clazz) {
-            final ClassMapping mapping = super.findOrCreateClassMapping(clazz);
+        public TypeMapping findOrCreateTypeMapping(final Type clazz) {
+            final TypeMapping mapping = super.findOrCreateTypeMapping(clazz);
             classes.remove(clazz); // no leak for single usage cases
             return mapping;
         }


### PR DESCRIPTION
Deserialization of enum from deserializationContext (normally used inside jsonbDeserializers).
This pull also contains a partial refactor for Mappings to manage TypeVariable and ParameterizedType.
I also fixed milli, micro, nano seconds formatting for date/temporal accessor types being truncated.