### PR TITLE
Fix JsonParser.getValue

### DIFF
--- a/johnzon-core/src/main/java/org/apache/johnzon/core/JohnzonJsonParserImpl.java
+++ b/johnzon-core/src/main/java/org/apache/johnzon/core/JohnzonJsonParserImpl.java
@@ -61,12 +61,29 @@ public abstract class JohnzonJsonParserImpl implements JohnzonJsonParser {
     @Override
     public JsonValue getValue() {
         Event current = current();
-        if (current != Event.START_ARRAY && current != Event.START_OBJECT) {
-            throw new IllegalStateException(current + " doesn't support getArray()");
+        switch (current) {
+            case START_ARRAY:
+            case START_OBJECT:
+                JsonReaderImpl jsonReader = new JsonReaderImpl(this, true);
+                return jsonReader.readValue();
+            case VALUE_TRUE:
+                return JsonValue.TRUE;
+            case VALUE_FALSE:
+                return JsonValue.FALSE;
+            case VALUE_NULL:
+                return JsonValue.NULL;
+            case VALUE_STRING:
+            case KEY_NAME:
+                return new JsonStringImpl(getString());
+            case VALUE_NUMBER:
+                if (isIntegralNumber()) {
+                    return new JsonLongImpl(getLong());
+                } else {
+                    return new JsonNumberImpl(getBigDecimal());
+                }
+            default:
+                throw new IllegalStateException(current + " doesn't support getValue()");
         }
-
-        JsonReaderImpl jsonReader = new JsonReaderImpl(this, true);
-        return jsonReader.readValue();
     }
 
     @Override

--- a/johnzon-core/src/test/java/org/apache/johnzon/core/JsonParserTest.java
+++ b/johnzon-core/src/test/java/org/apache/johnzon/core/JsonParserTest.java
@@ -42,6 +42,7 @@ import javax.json.JsonException;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonReader;
+import javax.json.JsonValue;
 import javax.json.stream.JsonParser;
 import javax.json.stream.JsonParser.Event;
 import javax.json.stream.JsonParsingException;
@@ -71,6 +72,54 @@ public class JsonParserTest {
         JsonParser parser = Json.createParser(new StringReader(json));
         JsonObject jsonObject = parser.getObject();
         Assert.assertNotNull(jsonObject);
+    }
+    
+    @Test
+    public void testGetValueOfStringType() {
+        String json = "\"abc\"";
+        JsonParser parser = Json.createParser(new StringReader(json));
+        JsonValue jsonValue = parser.getValue();
+        assertEquals(Json.createValue("abc"), jsonValue);
+    }
+
+    @Test
+    public void testGetValueOfNumberType() {
+        String json = "3.14";
+        JsonParser parser = Json.createParser(new StringReader(json));
+        JsonValue jsonValue = parser.getValue();
+        assertEquals(Json.createValue(new BigDecimal("3.14")), jsonValue);
+    }
+
+    @Test
+    public void testGetValueOfIntegerType() {
+        String json = "42";
+        JsonParser parser = Json.createParser(new StringReader(json));
+        JsonValue jsonValue = parser.getValue();
+        assertEquals(Json.createValue(42), jsonValue);
+    }
+
+    @Test
+    public void testGetValueOfTrueType() {
+        String json = "true";
+        JsonParser parser = Json.createParser(new StringReader(json));
+        JsonValue jsonValue = parser.getValue();
+        assertEquals(JsonValue.TRUE, jsonValue);
+    }
+
+    @Test
+    public void testGetValueOfFalseType() {
+        String json = "false";
+        JsonParser parser = Json.createParser(new StringReader(json));
+        JsonValue jsonValue = parser.getValue();
+        assertEquals(JsonValue.FALSE, jsonValue);
+    }
+
+    @Test
+    public void testGetValueOfNullType() {
+        String json = "null";
+        JsonParser parser = Json.createParser(new StringReader(json));
+        JsonValue jsonValue = parser.getValue();
+        assertEquals(JsonValue.NULL, jsonValue);
     }
 
     private void assertSimple(final JsonParser parser) {


### PR DESCRIPTION
JsonParser.getValue API method does not work correctly if the current value is other than array or object.

Some test cases are added for getting value of string, number, integer, true, false and null.
Please change the name of test methods if they does not match the naming convention.
