### PR TITLE
JOHNZON-209 Fix JsonObject#toString() to escape key names.

### DIFF
--- a/johnzon-core/src/main/java/org/apache/johnzon/core/JsonObjectImpl.java
+++ b/johnzon-core/src/main/java/org/apache/johnzon/core/JsonObjectImpl.java
@@ -147,7 +147,9 @@ final class JsonObjectImpl extends AbstractMap<String, JsonValue> implements Jso
         while (hasNext) {
             final Map.Entry<String, JsonValue> entry = it.next();
 
-            builder.append('"').append(Strings.escape(entry.getKey())).append("\":");
+            builder.append('"');
+            Strings.appendEscaped(entry.getKey(), builder);
+            builder.append("\":");
 
             final JsonValue value = entry.getValue();
             if (JsonString.class.isInstance(value)) {

--- a/johnzon-core/src/main/java/org/apache/johnzon/core/JsonObjectImpl.java
+++ b/johnzon-core/src/main/java/org/apache/johnzon/core/JsonObjectImpl.java
@@ -147,7 +147,7 @@ final class JsonObjectImpl extends AbstractMap<String, JsonValue> implements Jso
         while (hasNext) {
             final Map.Entry<String, JsonValue> entry = it.next();
 
-            builder.append('"').append(entry.getKey()).append("\":");
+            builder.append('"').append(Strings.escape(entry.getKey())).append("\":");
 
             final JsonValue value = entry.getValue();
             if (JsonString.class.isInstance(value)) {

--- a/johnzon-core/src/test/java/org/apache/johnzon/core/JsonObjectImplTest.java
+++ b/johnzon-core/src/test/java/org/apache/johnzon/core/JsonObjectImplTest.java
@@ -75,6 +75,19 @@ public class JsonObjectImplTest {
         assertEquals("{\"a\":\"b\"}", ob.build().toString());
     }
 
+    @Test
+    public void testToStringShouldReturnEscapedKey() {
+        final JsonObjectBuilder ob = Json.createObjectBuilder();
+        ob.add("foo\"bar", new JsonLongImpl(42));
+        assertEquals("{\"foo\\\"bar\":42}", ob.build().toString());
+    }
+
+    @Test
+    public void testToStringShouldReturnEscapedValue() {
+        final JsonObjectBuilder ob = Json.createObjectBuilder();
+        ob.add("a", new JsonStringImpl("foo\"bar"));
+        assertEquals("{\"a\":\"foo\\\"bar\"}", ob.build().toString());
+    }
 
     @Test(expected = NullPointerException.class)
     public void testGetBooleanMissingKeyShouldThrowNullPointerException() {


### PR DESCRIPTION
This PR will fix JOHNZON-209 with additional test cases.