### PR TITLE
Explicit note that Polymorphic does not support withSerializers / withDeserializers

### DIFF
--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -480,6 +480,8 @@ bind the corresponding serializer and/or deserializer:
         public List<Root> roots;
     }
 
+Binding the polymophic serializer and/or deserializer *must not* be done using `JsonbConfig.withSerializers` / `JsonbConfig.withDeserializers`, as it is designed to work *only* with binding performed *using annotations*.
+
 
 ### JSON Schema
 


### PR DESCRIPTION
Explicitly warning that binding of Polymorphic.(De)Serializer MUST NOT be done by with(De)Serializer, as @rmannibucau said this is by design *only* working with annotation-binding.

(Continuation from https://github.com/eclipse-ee4j/jsonb-api/issues/147#issuecomment-523833911)