### PR TITLE
Fix for [JOHNZON-276]: StackOverflowError

### DIFF
--- a/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/DefaultPropertyVisibilityStrategy.java
+++ b/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/DefaultPropertyVisibilityStrategy.java
@@ -40,14 +40,14 @@ public class DefaultPropertyVisibilityStrategy implements javax.json.bind.config
         }
         final PropertyVisibilityStrategy strategy = strategies.computeIfAbsent(
                 field.getDeclaringClass(), this::visibilityStrategy);
-        return strategy == this ? Modifier.isPublic(field.getModifiers()) : strategy.isVisible(field);
+        return this.equals(strategy) ? Modifier.isPublic(field.getModifiers()) : strategy.isVisible(field);
     }
 
     @Override
     public boolean isVisible(final Method method) {
         final PropertyVisibilityStrategy strategy = strategies.computeIfAbsent(
                 method.getDeclaringClass(), this::visibilityStrategy);
-        return strategy == this ? Modifier.isPublic(method.getModifiers()) : strategy.isVisible(method);
+        return this.equals(strategy) ? Modifier.isPublic(method.getModifiers()) : strategy.isVisible(method);
     }
 
     private PropertyVisibilityStrategy visibilityStrategy(final Class<?> type) { // can be cached
@@ -86,5 +86,10 @@ public class DefaultPropertyVisibilityStrategy implements javax.json.bind.config
             }
         }
         return this;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        return o instanceof DefaultPropertyVisibilityStrategy;
     }
 }


### PR DESCRIPTION
The following code produces a StackOverflowError:
```java
@JsonVisibility(DefaultPropertyVisibilityStrategy.class)
public final class C
{
   @JsonProperty private boolean foo;
}
```
The problem is caused by the fact that this strategy tries to compare "this" by "==" with a new instance of itself, which certainly fails, because the new copy is definitively a different reference than the one currently executed and instantiated due to the class annotation.

The fix is simple: Adding an equals method just comparing the class type (as the strategy has no members other than a cache), and calling that instead of "==".