### PR TITLE
[JOHNZON-278] Return constant instead of new instance of empty block / empty array

### DIFF
--- a/johnzon-core/src/main/java/org/apache/johnzon/core/JsonArrayBuilderImpl.java
+++ b/johnzon-core/src/main/java/org/apache/johnzon/core/JsonArrayBuilderImpl.java
@@ -298,7 +298,7 @@ class JsonArrayBuilderImpl implements JsonArrayBuilder, Serializable {
         addValue(builder.build());
         return this;
     }
-    
+
     private void setValue(int idx, JsonValue value) {
         if (value == null || tmpList == null) {
             throw npe();
@@ -333,7 +333,7 @@ class JsonArrayBuilderImpl implements JsonArrayBuilder, Serializable {
     @Override
     public JsonArray build() {
         if(tmpList == null) {
-            return new JsonArrayImpl(Collections.emptyList(), bufferProvider);
+            return JsonValue.EMPTY_JSON_ARRAY;
         }
         return new JsonArrayImpl(Collections.unmodifiableList(tmpList), bufferProvider);
     }

--- a/johnzon-core/src/main/java/org/apache/johnzon/core/JsonObjectBuilderImpl.java
+++ b/johnzon-core/src/main/java/org/apache/johnzon/core/JsonObjectBuilderImpl.java
@@ -176,16 +176,16 @@ class JsonObjectBuilderImpl implements JsonObjectBuilder, Serializable {
         if(name == null || value == null) {
             throw new NullPointerException("name or value/builder must not be null");
         }
-        
+
         attributeMap.put(name, value);
     }
-    
+
 
     @Override
     public JsonObject build() {
-        
+
         if(attributeMap == null || attributeMap.isEmpty()) {
-            return new JsonObjectImpl(Collections.EMPTY_MAP, bufferProvider);
+            return JsonValue.EMPTY_JSON_OBJECT;
         } else {
             Map<String, JsonValue> dump = (Collections.unmodifiableMap(attributeMap));
             return new JsonObjectImpl(dump, bufferProvider);

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
   <url>http://johnzon.apache.org</url>
 
   <properties>
-    <geronimo-jsonp.version>1.2</geronimo-jsonp.version>
+    <geronimo-jsonp.version>1.3-SNAPSHOT</geronimo-jsonp.version>
     <geronimo-jsonb.version>1.2</geronimo-jsonb.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <johnzon.site.url>https://svn.apache.org/repos/asf/johnzon/site/publish/</johnzon.site.url>


### PR DESCRIPTION
Even in these days of modern Java, reducing memory consumption, GC stress and memory fragmentation, are beneficial side aspects.

If makes no sense to create new **empty** instances of JsonArray and JsonObject again and again. For this case, JSON-P provides special **constants**.

It makes sense to return these constants always.