### PR TITLE
Enabled test as it seems to run well.

### DIFF
--- a/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/serializer/DeserializationContextTest.java
+++ b/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/serializer/DeserializationContextTest.java
@@ -50,7 +50,7 @@ public class DeserializationContextTest {
             final Foo foo = jsonb.fromJson("{\"bar\":{},\"bars\":[]}", Foo.class);
             assertNotNull(foo);
             assertNotNull(foo.bar);
-            // assertNotNull(foo.bars); <- There seems to be a nother bug as this one fails even without custom deserialization!
+            assertNotNull(foo.bars);
         }
 
         try (final Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().withDeserializers(new CustomDeserializer()))) {


### PR DESCRIPTION
Tried to reproduce the bug multiple times on Windows and Linux, but it did not happen anymore. The reason why this test was disabled seems to be gone. Hence it seems it was a local instability on my side, and it should be safe to enable this test now. Sorry for the confusion! :-)