### PR TITLE
JOHNZON-272 Fails to build Johnzon :: Maven Plugin

### DIFF
--- a/johnzon-maven-plugin/src/test/java/org/apache/johnzon/maven/plugin/ExampleToModelMojoTest.java
+++ b/johnzon-maven-plugin/src/test/java/org/apache/johnzon/maven/plugin/ExampleToModelMojoTest.java
@@ -111,7 +111,7 @@ public class ExampleToModelMojoTest {
         final File output = new File(targetFolder, "org/test/apache/johnzon/mojo/SomeValue.java");
         assertTrue(output.isFile());
         assertEquals(
-            new String(IOUtil.toByteArray(Thread.currentThread().getContextClassLoader().getResourceAsStream("SomeValue.java"))),
+            new String(IOUtil.toByteArray(Thread.currentThread().getContextClassLoader().getResourceAsStream("SomeValue.java"))).replace("\r\n", "\n"),
             new String(IOUtil.toByteArray(new FileReader(output))).replace(File.separatorChar, '/'));
     }
 }


### PR DESCRIPTION
```bash
$ git clone https://github.com/apache/johnzon.git
$ cd johnzon
$ mvn clean install
...
[INFO] Running org.apache.johnzon.maven.plugin.ExampleToModelMojoTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.172 s <<< FAILURE! - in org.apache.johnzon.maven.plugin.ExampleToModelMojoTest
[ERROR] generate(org.apache.johnzon.maven.plugin.ExampleToModelMojoTest) Time elapsed: 0.125 s <<< FAILURE!
org.junit.ComparisonFailure:
expected:</*[
{{ * Licensed to the Apache Software Foundation (ASF) under one}}
...