### PR TITLE
JOHNZON-279 Fails to build on Travis CI (Xenial)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ sudo: false
 
 jdk:
   - openjdk8
-before_install: mvn clean install -DskipTests=true
+before_install: mvn -q clean install -DskipTests=true
 after_success:
-  - mvn clean cobertura:cobertura coveralls:report
+  - mvn -q clean cobertura:cobertura coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 sudo: false
 
 jdk:
-  - oraclejdk8 
+  - openjdk8
 before_install: mvn clean install -DskipTests=true
 after_success:
   - mvn clean cobertura:cobertura coveralls:report


### PR DESCRIPTION
Seems there are several causes.

Cause 1: https://travis-ci.community/t/install-of-oracle-jdk-8-failing

Cause 2: "The job exceeded the maximum log length, and has been terminated."