### PR TITLE
JOHNZON-272 Incorrect EOL created on Windows

### DIFF
--- a/johnzon-maven-plugin/src/test/java/org/apache/johnzon/maven/plugin/ExampleToModelMojoTest.java
+++ b/johnzon-maven-plugin/src/test/java/org/apache/johnzon/maven/plugin/ExampleToModelMojoTest.java
@@ -41,23 +41,23 @@ public class ExampleToModelMojoTest {
             target = targetFolder;
             packageBase = "org.test.apache.johnzon.mojo";
             header =
-                "/*\n" +
-                " * Licensed to the Apache Software Foundation (ASF) under one\n" +
-                " * or more contributor license agreements. See the NOTICE file\n" +
-                " * distributed with this work for additional information\n" +
-                " * regarding copyright ownership. The ASF licenses this file\n" +
-                " * to you under the Apache License, Version 2.0 (the\n" +
-                " * \"License\"); you may not use this file except in compliance\n" +
-                " * with the License. You may obtain a copy of the License at\n" +
-                " *\n" +
-                " * http://www.apache.org/licenses/LICENSE-2.0\n" +
-                " *\n" +
-                " * Unless required by applicable law or agreed to in writing,\n" +
-                " * software distributed under the License is distributed on an\n" +
-                " * \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n" +
-                " * KIND, either express or implied. See the License for the\n" +
-                " * specific language governing permissions and limitations\n" +
-                " * under the License.\n" +
+                "/*%n" +
+                " * Licensed to the Apache Software Foundation (ASF) under one%n" +
+                " * or more contributor license agreements. See the NOTICE file%n" +
+                " * distributed with this work for additional information%n" +
+                " * regarding copyright ownership. The ASF licenses this file%n" +
+                " * to you under the Apache License, Version 2.0 (the%n" +
+                " * \"License\"); you may not use this file except in compliance%n" +
+                " * with the License. You may obtain a copy of the License at%n" +
+                " *%n" +
+                " * http://www.apache.org/licenses/LICENSE-2.0%n" +
+                " *%n" +
+                " * Unless required by applicable law or agreed to in writing,%n" +
+                " * software distributed under the License is distributed on an%n" +
+                " * \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY%n" +
+                " * KIND, either express or implied. See the License for the%n" +
+                " * specific language governing permissions and limitations%n" +
+                " * under the License.%n" +
                 " */";
         }};
 
@@ -111,7 +111,7 @@ public class ExampleToModelMojoTest {
         final File output = new File(targetFolder, "org/test/apache/johnzon/mojo/SomeValue.java");
         assertTrue(output.isFile());
         assertEquals(
-            new String(IOUtil.toByteArray(Thread.currentThread().getContextClassLoader().getResourceAsStream("SomeValue.java"))).replace("\r\n", "\n"),
+            new String(IOUtil.toByteArray(Thread.currentThread().getContextClassLoader().getResourceAsStream("SomeValue.java"))),
             new String(IOUtil.toByteArray(new FileReader(output))).replace(File.separatorChar, '/'));
     }
 }


### PR DESCRIPTION
On Windows, `.java` source files do have `CR LF` endings typically. If creating `LF` endings only (just like on Linux), native Windows editors will show the resulting source file as one single line. To work correctly on **all** operating systems, this change does _not_ imply _any_ particular EOL sequence, but offloads this task to the JRE.