### PR TITLE
JOHNZON-272 Fails to build Maven Plugin - Alternative Solution

### DIFF
--- a/johnzon-maven-plugin/.gitattributes
+++ b/johnzon-maven-plugin/.gitattributes
@@ -1,0 +1,16 @@
+#  Copyright (C) 2019 Markus KARG
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+src/test/resources/SomeValue.java text eol=lf
+

--- a/johnzon-maven-plugin/src/test/java/org/apache/johnzon/maven/plugin/ExampleToModelMojoTest.java
+++ b/johnzon-maven-plugin/src/test/java/org/apache/johnzon/maven/plugin/ExampleToModelMojoTest.java
@@ -111,7 +111,7 @@ public class ExampleToModelMojoTest {
         final File output = new File(targetFolder, "org/test/apache/johnzon/mojo/SomeValue.java");
         assertTrue(output.isFile());
         assertEquals(
-            new String(IOUtil.toByteArray(Thread.currentThread().getContextClassLoader().getResourceAsStream("SomeValue.java"))).replace("\r\n", "\n"),
+            new String(IOUtil.toByteArray(Thread.currentThread().getContextClassLoader().getResourceAsStream("SomeValue.java"))),
             new String(IOUtil.toByteArray(new FileReader(output))).replace(File.separatorChar, '/'));
     }
 }


### PR DESCRIPTION
Using `.gitattributes` to guarantee LF line endings instead of explicitly replacing wrong line endings in Java code.

See https://github.com/apache/johnzon/pull/50#issuecomment-534668791.

I confirm it actually solves JOHNZON-272 on both, Linux (tried with Gitpod) and Windows (tried with Windows 8.1).