### PR TITLE
JOHNZON-286 Making DefaultPropertyVisibilityStrategy non-public

### DIFF
--- a/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/DefaultPropertyVisibilityStrategy.java
+++ b/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/DefaultPropertyVisibilityStrategy.java
@@ -30,7 +30,7 @@ import javax.json.bind.annotation.JsonbProperty;
 import javax.json.bind.annotation.JsonbVisibility;
 import javax.json.bind.config.PropertyVisibilityStrategy;
 
-public class DefaultPropertyVisibilityStrategy implements javax.json.bind.config.PropertyVisibilityStrategy {
+class DefaultPropertyVisibilityStrategy implements javax.json.bind.config.PropertyVisibilityStrategy {
     private final ConcurrentMap<Class<?>, PropertyVisibilityStrategy> strategies = new ConcurrentHashMap<>();
 
     @Override


### PR DESCRIPTION
According to apparent concensus among the Johnzon contributors, the class `DefaultPropertyVisibilityStrategy` should not be `public` anymore.

This in turn reduces the need to fix [JOHNZON-276](https://issues.apache.org/jira/browse/JOHNZON-276) by #44.

Closes [JOHNZON-286](https://issues.apache.org/jira/browse/JOHNZON-286).