### PR TITLE
Use the configured charset instead of always relying on the default one (backport from 'master')

### DIFF
--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mapper.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mapper.java
@@ -40,6 +40,7 @@ import java.lang.reflect.Array;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -177,10 +178,9 @@ public class Mapper implements Closeable {
     public void writeObject(final Object object, final OutputStream stream) {
         Charset charset = config.getEncoding();
         if (charset == null) {
-            writeObject(object, new OutputStreamWriter(stream));
-        } else {
-            writeObject(object, new OutputStreamWriter(stream));
+            charset = StandardCharsets.UTF_8;
         }
+        writeObject(object, new OutputStreamWriter(stream, charset));
     }
 
     private void writeObject(final Object object, final JsonGenerator generator, final Collection<String> ignored, JsonPointerTracker jsonPointer) {


### PR DESCRIPTION
This fixes an issue with JAX-RS in TomEE 7.0.x when serializing objects with non-ASCII characters on machines where the default charset is not an UTF-8. 