### PR TITLE
Added possibility to use minus as array index for the remove operation.

### DIFF
--- a/johnzon-core/src/main/java/org/apache/johnzon/core/JsonPointerImpl.java
+++ b/johnzon-core/src/main/java/org/apache/johnzon/core/JsonPointerImpl.java
@@ -339,8 +339,7 @@ public class JsonPointerImpl implements JsonPointer {
 
             try {
                 JsonArray jsonArray = (JsonArray) jsonValue;
-                int arrayIndex = Integer.parseInt(referenceToken);
-                validateArraySize(jsonArray, arrayIndex, jsonArray.size());
+                int arrayIndex = getArrayIndex(referenceToken, jsonArray, false);
                 return jsonArray.get(arrayIndex);
             } catch (NumberFormatException e) {
                 throw new JsonException("'" + referenceToken + "' is no valid array index", e);
@@ -460,6 +459,8 @@ public class JsonPointerImpl implements JsonPointer {
     private int getArrayIndex(String referenceToken, JsonArray jsonArray, boolean addOperation) {
         if (addOperation && referenceToken.equals("-")) {
             return jsonArray.size();
+        } else if (!addOperation && referenceToken.equals("-")) {
+            return jsonArray.size() - 1;
         }
 
         validateArrayIndex(referenceToken);
@@ -486,7 +487,7 @@ public class JsonPointerImpl implements JsonPointer {
     }
 
     private void validateArrayIndex(String referenceToken) throws JsonException {
-        if (referenceToken.startsWith("+") || referenceToken.startsWith("-")) {
+        if (referenceToken.startsWith("+") || (referenceToken.startsWith("-") && referenceToken.length() > 1)) {
             throw new JsonException("An array index must not start with '" + referenceToken.charAt(0) + "'");
         }
         if (referenceToken.startsWith("0") && referenceToken.length() > 1) {

--- a/johnzon-core/src/test/java/org/apache/johnzon/core/JsonPointerTest.java
+++ b/johnzon-core/src/test/java/org/apache/johnzon/core/JsonPointerTest.java
@@ -457,6 +457,19 @@ public class JsonPointerTest {
     }
 
     @Test
+    public void testRemoveLastArrayElement() {
+        JsonPointerImpl jsonPointer = new JsonPointerImpl(JsonProvider.provider(), "/0/-");
+        JsonStructure target = Json.createArrayBuilder()
+                .add(Json.createArrayBuilder()
+                        .add("bar")
+                        .add("qux")
+                        .add("baz")).build(); // [["bar","qux","baz"]]
+
+        JsonStructure result = jsonPointer.remove(target);
+        assertEquals("[[\"bar\",\"qux\"]]", result.toString()); // [["bar","baz"]]
+    }
+
+    @Test
     public void testRemoveObjectMember() {
         JsonPointerImpl jsonPointer = new JsonPointerImpl(JsonProvider.provider(), "/baz");
         JsonStructure target = Json.createObjectBuilder()

--- a/johnzon-core/src/test/java/org/apache/johnzon/core/JsonPointerTest.java
+++ b/johnzon-core/src/test/java/org/apache/johnzon/core/JsonPointerTest.java
@@ -466,7 +466,7 @@ public class JsonPointerTest {
                         .add("baz")).build(); // [["bar","qux","baz"]]
 
         JsonStructure result = jsonPointer.remove(target);
-        assertEquals("[[\"bar\",\"qux\"]]", result.toString()); // [["bar","baz"]]
+        assertEquals("[[\"bar\",\"qux\"]]", result.toString()); // [["bar","qux"]]
     }
 
     @Test


### PR DESCRIPTION
## Problem

Currently it is not allowed to remove an entry by using a `-` as array index.
Since it is allowed for the add operation, it should also be allowed for all the other operations.
Further this is necessary if johnzon is used together with the JSON Patch library.

## Solution

I've added a check for the `-` index in the `getArrayIndex` method to return the index of the last entry.
Additionally I've made the check in the `validateArrayIndex` more explicit.

## Test(s) added 

One test that perform a remove with a `-` as array index.
