### PR TITLE
Switch to Jakarta JSON Processing API

### DIFF
--- a/johnzon-distribution/pom.xml
+++ b/johnzon-distribution/pom.xml
@@ -30,22 +30,22 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-json_1.1_spec</artifactId>
-      <version>${geronimo-jsonp.version}</version>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
+      <version>${json-api.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-json_1.1_spec</artifactId>
-      <version>${geronimo-jsonp.version}</version>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
+      <version>${json-api.version}</version>
       <scope>compile</scope>
       <classifier>sources</classifier>
     </dependency>
     <dependency>
-      <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-json_1.1_spec</artifactId>
-      <version>${geronimo-jsonp.version}</version>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
+      <version>${json-api.version}</version>
       <scope>compile</scope>
       <classifier>javadoc</classifier>
     </dependency>

--- a/johnzon-maven-plugin/pom.xml
+++ b/johnzon-maven-plugin/pom.xml
@@ -37,9 +37,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-json_1.1_spec</artifactId>
-      <version>${geronimo-jsonp.version}</version>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
+      <version>${json-api.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -76,7 +76,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.4</version>
+        <version>3.5.2</version>
         <executions>
           <execution>
             <id>mojo-descriptor</id>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
   <url>http://johnzon.apache.org</url>
 
   <properties>
-    <geronimo-jsonp.version>1.3</geronimo-jsonp.version>
+    <json-api.version>1.1.6</json-api.version>
     <geronimo-jsonb.version>1.2</geronimo-jsonb.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <johnzon.site.url>https://svn.apache.org/repos/asf/johnzon/site/publish/</johnzon.site.url>
@@ -80,9 +80,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-json_1.1_spec</artifactId>
-      <version>${geronimo-jsonp.version}</version>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
+      <version>${json-api.version}</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
geronimo-json_1.1_spec dependency cause extra manifest entry:

Require-Capability: osgi.extender;filter:="(osgi.extender=osgi.service
 loader.registrar)",**osgi.contract;osgi.contract=JavaJSONP;filter:="(&(
 osgi.contract=JavaJSONP)(version=1.1.0))"**,osgi.ee;filter:="(&(osgi.ee
 =JavaSE)(version=1.8))"