### PR TITLE
[JOHNZON-327] Json Schema Validation: added integer type validation.

### DIFF
--- a/johnzon-jsonschema/src/main/java/org/apache/johnzon/jsonschema/JsonSchemaValidatorFactory.java
+++ b/johnzon-jsonschema/src/main/java/org/apache/johnzon/jsonschema/JsonSchemaValidatorFactory.java
@@ -43,6 +43,7 @@ import org.apache.johnzon.jsonschema.spi.builtin.ContainsValidation;
 import org.apache.johnzon.jsonschema.spi.builtin.EnumValidation;
 import org.apache.johnzon.jsonschema.spi.builtin.ExclusiveMaximumValidation;
 import org.apache.johnzon.jsonschema.spi.builtin.ExclusiveMinimumValidation;
+import org.apache.johnzon.jsonschema.spi.builtin.IntegerValidation;
 import org.apache.johnzon.jsonschema.spi.builtin.ItemsValidation;
 import org.apache.johnzon.jsonschema.spi.builtin.MaxItemsValidation;
 import org.apache.johnzon.jsonschema.spi.builtin.MaxLengthValidation;
@@ -88,6 +89,7 @@ public class JsonSchemaValidatorFactory implements AutoCloseable {
         return asList(
                 new RequiredValidation(),
                 new TypeValidation(),
+                new IntegerValidation(),
                 new EnumValidation(),
                 new MultipleOfValidation(),
                 new MaximumValidation(),

--- a/johnzon-jsonschema/src/main/java/org/apache/johnzon/jsonschema/spi/builtin/IntegerValidation.java
+++ b/johnzon-jsonschema/src/main/java/org/apache/johnzon/jsonschema/spi/builtin/IntegerValidation.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 import javax.json.JsonNumber;
 import javax.json.JsonString;
 import javax.json.JsonValue;
+import javax.json.JsonValue.ValueType;
 
 import org.apache.johnzon.jsonschema.ValidationResult;
 import org.apache.johnzon.jsonschema.ValidationResult.ValidationError;
@@ -18,33 +19,10 @@ public class IntegerValidation implements ValidationExtension {
 	@Override
 	public Optional<Function<JsonValue, Stream<ValidationError>>> create(ValidationContext model) {
 		final JsonValue type = model.getSchema().get("type");
-		if (JsonString.class.isInstance(type) && "integer".equals(JsonString.class.cast(type).getString())) {
-			return Optional.of(new Impl(model.toPointer(), model.getValueProvider()));
+		if (type.getValueType().equals(ValueType.STRING) && "integer".equals(JsonString.class.cast(type).getString())) {
+			return Optional.of(new MultipleOfValidation.Impl(model.toPointer(), model.getValueProvider(), 1));
 		}
 		return Optional.empty();
 	}
 
-	private static class Impl extends BaseValidation {
-
-		private Impl(final String pointer, final Function<JsonValue, JsonValue> valueProvider) {
-			super(pointer, valueProvider, JsonValue.ValueType.NUMBER);
-		}
-
-		@Override
-		protected Stream<ValidationError> onNumber(JsonNumber number) {
-			final double value = number.doubleValue();
-			if (value % 1 == 0) {
-				return Stream.empty();
-			} else {
-				return Stream.of(new ValidationResult.ValidationError(pointer, "Expected integer but got " + value));
-			}
-		}
-
-		@Override
-		public String toString() {
-			return "Integer{" + 
-					"pointer='" + pointer + '\'' + 
-					'}';
-		}
-	}
 }

--- a/johnzon-jsonschema/src/main/java/org/apache/johnzon/jsonschema/spi/builtin/IntegerValidation.java
+++ b/johnzon-jsonschema/src/main/java/org/apache/johnzon/jsonschema/spi/builtin/IntegerValidation.java
@@ -1,0 +1,50 @@
+package org.apache.johnzon.jsonschema.spi.builtin;
+
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import javax.json.JsonNumber;
+import javax.json.JsonString;
+import javax.json.JsonValue;
+
+import org.apache.johnzon.jsonschema.ValidationResult;
+import org.apache.johnzon.jsonschema.ValidationResult.ValidationError;
+import org.apache.johnzon.jsonschema.spi.ValidationContext;
+import org.apache.johnzon.jsonschema.spi.ValidationExtension;
+
+public class IntegerValidation implements ValidationExtension {
+
+	@Override
+	public Optional<Function<JsonValue, Stream<ValidationError>>> create(ValidationContext model) {
+		final JsonValue type = model.getSchema().get("type");
+		if (JsonString.class.isInstance(type) && "integer".equals(JsonString.class.cast(type).getString())) {
+			return Optional.of(new Impl(model.toPointer(), model.getValueProvider()));
+		}
+		return Optional.empty();
+	}
+
+	private static class Impl extends BaseValidation {
+
+		private Impl(final String pointer, final Function<JsonValue, JsonValue> valueProvider) {
+			super(pointer, valueProvider, JsonValue.ValueType.NUMBER);
+		}
+
+		@Override
+		protected Stream<ValidationError> onNumber(JsonNumber number) {
+			final double value = number.doubleValue();
+			if (value % 1 == 0) {
+				return Stream.empty();
+			} else {
+				return Stream.of(new ValidationResult.ValidationError(pointer, "Expected integer but got " + value));
+			}
+		}
+
+		@Override
+		public String toString() {
+			return "Integer{" + 
+					"pointer='" + pointer + '\'' + 
+					'}';
+		}
+	}
+}

--- a/johnzon-jsonschema/src/main/java/org/apache/johnzon/jsonschema/spi/builtin/MultipleOfValidation.java
+++ b/johnzon-jsonschema/src/main/java/org/apache/johnzon/jsonschema/spi/builtin/MultipleOfValidation.java
@@ -40,8 +40,8 @@ public class MultipleOfValidation implements ValidationExtension {
         return Optional.empty();
     }
 
-    private static class Impl extends BaseNumberValidation {
-        private Impl(final String pointer, final Function<JsonValue, JsonValue> valueProvider, final double multipleOf) {
+    static class Impl extends BaseNumberValidation {
+        Impl(final String pointer, final Function<JsonValue, JsonValue> valueProvider, final double multipleOf) {
             super(pointer, valueProvider, multipleOf);
         }
 

--- a/johnzon-jsonschema/src/main/java/org/apache/johnzon/jsonschema/spi/builtin/TypeValidation.java
+++ b/johnzon-jsonschema/src/main/java/org/apache/johnzon/jsonschema/spi/builtin/TypeValidation.java
@@ -55,6 +55,7 @@ public class TypeValidation implements ValidationExtension {
             case "string":
                 return Stream.of(JsonValue.ValueType.STRING);
             case "number":
+            case "integer":
                 return Stream.of(JsonValue.ValueType.NUMBER);
             case "array":
                 return Stream.of(JsonValue.ValueType.ARRAY);

--- a/johnzon-jsonschema/src/test/java/org/apache/johnzon/jsonschema/JsonSchemaValidatorTest.java
+++ b/johnzon-jsonschema/src/test/java/org/apache/johnzon/jsonschema/JsonSchemaValidatorTest.java
@@ -23,6 +23,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Collection;
 
 import javax.json.Json;
@@ -369,8 +371,12 @@ public class JsonSchemaValidatorTest {
 
         assertTrue(validator.apply(jsonFactory.createObjectBuilder().build()).isSuccess());
         assertTrue(validator.apply(jsonFactory.createObjectBuilder().add("age", 30).build()).isSuccess());
+        assertTrue(validator.apply(jsonFactory.createObjectBuilder().add("age", -10).build()).isSuccess());
+        assertTrue(validator.apply(jsonFactory.createObjectBuilder().add("age", BigInteger.valueOf(50)).build()).isSuccess());
         // check no decimal numbers allowed
-        assertFalse(validator.apply(jsonFactory.createObjectBuilder() .add("age", 30.3) .build()).isSuccess());
+        assertFalse(validator.apply(jsonFactory.createObjectBuilder() .add("age", 30.3f) .build()).isSuccess());
+        assertFalse(validator.apply(jsonFactory.createObjectBuilder() .add("age", -7.4d) .build()).isSuccess());
+        assertFalse(validator.apply(jsonFactory.createObjectBuilder() .add("age", BigDecimal.valueOf(50.35613d)).build()).isSuccess());
         
         validator.close();
     }

--- a/johnzon-jsonschema/src/test/java/org/apache/johnzon/jsonschema/JsonSchemaValidatorTest.java
+++ b/johnzon-jsonschema/src/test/java/org/apache/johnzon/jsonschema/JsonSchemaValidatorTest.java
@@ -355,6 +355,25 @@ public class JsonSchemaValidatorTest {
 
         validator.close();
     }
+    
+    @Test
+    public void integerType() {
+    	final JsonSchemaValidator validator = factory.newInstance(jsonFactory.createObjectBuilder()
+                .add("type", "object")
+                .add("properties", jsonFactory.createObjectBuilder()
+                        .add("age", jsonFactory.createObjectBuilder()
+                                .add("type", "integer")
+                                .build())
+                        .build())
+                .build());
+
+        assertTrue(validator.apply(jsonFactory.createObjectBuilder().build()).isSuccess());
+        assertTrue(validator.apply(jsonFactory.createObjectBuilder().add("age", 30).build()).isSuccess());
+        // check no decimal numbers allowed
+        assertFalse(validator.apply(jsonFactory.createObjectBuilder() .add("age", 30.3) .build()).isSuccess());
+        
+        validator.close();
+    }
 
     @Test
     public void minLength() {
@@ -657,4 +676,6 @@ public class JsonSchemaValidatorTest {
 
         validator.close();
     }
+    
+
 }


### PR DESCRIPTION
Hi!
As per the official json-schema specification, integer type validation is missing from the current implementation.
http://json-schema.org/understanding-json-schema/reference/numeric.html

This PR tries to tackle that in the least intrusive way possible.
Thanks in advance!