### PR TITLE
Fix InaccessibleObjectException on JDK16+

### DIFF
--- a/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/JsonbWriteTest.java
+++ b/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/JsonbWriteTest.java
@@ -28,8 +28,10 @@ import javax.json.bind.spi.JsonbProvider;
 import java.io.ByteArrayOutputStream;
 import java.io.StringWriter;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
@@ -92,6 +94,14 @@ public class JsonbWriteTest {
         assertEquals("[\"a\",\"b\"]", JsonbProvider.provider().create().build().toJson(map));
     }
 
+    @Test
+    public void listOfSimple() {
+        final List<Simple> list = new ArrayList<>();
+        list.add(new Simple());
+        list.add(new Simple());
+        assertEquals("[{},{}]", JsonbProvider.provider().create().build().toJson(list, List.class));
+    }
+    
     @Test
     public void propertyMappingNotNillable() {
         final SimpleProperty simple = new SimpleProperty();

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mappings.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mappings.java
@@ -508,17 +508,14 @@ public class Mappings {
 
         final Method anyGetter = accessMode.findAnyGetter(clazz);
         final Field anyField = accessMode.findAnyField(clazz);
+        
         final ClassMapping mapping = new ClassMapping(
                 clazz, accessMode.findFactory(clazz), getters, setters,
                 accessMode.findAdapter(clazz),
                 accessMode.findReader(clazz),
                 accessMode.findWriter(clazz),
-                anyGetter != null ? MethodAccessMode.MethodReader.create(anyGetter, anyGetter.getReturnType())
-                    .map(reader -> new Getter(reader, false,false, false, false, true, null, null, -1, null))
-                    .orElse(null) :
-                        (anyField != null ? FieldAccessMode.FieldReader.create(anyField, anyField.getGenericType())
-                             .map(reader -> new Getter(reader, false,false, false, false, true, null, null, -1, null))
-                             .orElse(null) : null),
+                anyGetter != null ? createMethodReader(anyGetter) :
+                    (anyField != null ? createFieldReader(anyField) : null),
                 accessMode.findAnySetter(clazz),
                 anyField,
                 Map.class.isAssignableFrom(clazz) ? accessMode.findMapAdder(clazz) : null);
@@ -526,6 +523,32 @@ public class Mappings {
         accessMode.afterParsed(clazz);
 
         return mapping;
+    }
+
+    private Getter createFieldReader(final Field anyField) {
+        if (anyField == null) {
+            return null;
+        }
+        
+        final FieldAccessMode.FieldReader reader = FieldAccessMode.FieldReader.create(anyField, anyField.getGenericType());
+        if (reader == null) {
+            return null;
+        }
+        
+        return new Getter(reader, false,false, false, false, true, null, null, -1, null);
+    }
+
+    private Getter createMethodReader(final Method anyGetter) {
+        if (anyGetter == null) {
+            return null;
+        }
+        
+        final MethodAccessMode.MethodReader reader = MethodAccessMode.MethodReader.create(anyGetter, anyGetter.getReturnType());
+        if (reader == null) {
+            return null;
+        }
+        
+        return new Getter(reader, false,false, false, false, true, null, null, -1, null);
     }
 
     protected Class<?> findModelClass(final Class<?> inClazz) {

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mappings.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mappings.java
@@ -530,8 +530,8 @@ public class Mappings {
             return null;
         }
         
-        final FieldAccessMode.FieldReader reader = FieldAccessMode.FieldReader.create(anyField, anyField.getGenericType());
-        if (reader == null) {
+        final FieldAccessMode.FieldReader reader = new FieldAccessMode.FieldReader(anyField, anyField.getGenericType());
+        if (!reader.isAccessible()) {
             return null;
         }
         
@@ -543,8 +543,8 @@ public class Mappings {
             return null;
         }
         
-        final MethodAccessMode.MethodReader reader = MethodAccessMode.MethodReader.create(anyGetter, anyGetter.getReturnType());
-        if (reader == null) {
+        final MethodAccessMode.MethodReader reader = new MethodAccessMode.MethodReader(anyGetter, anyGetter.getReturnType());
+        if (!reader.isAccessible()) {
             return null;
         }
         

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mappings.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mappings.java
@@ -513,11 +513,12 @@ public class Mappings {
                 accessMode.findAdapter(clazz),
                 accessMode.findReader(clazz),
                 accessMode.findWriter(clazz),
-                anyGetter != null ? new Getter(
-                        new MethodAccessMode.MethodReader(anyGetter, anyGetter.getReturnType()),
-                        false,false, false, false, true, null, null, -1, null) :
-                        (anyField != null ? new Getter(new FieldAccessMode.FieldReader(anyField, anyField.getGenericType()),
-                        false,false, false, false, true, null, null, -1, null) : null),
+                anyGetter != null ? MethodAccessMode.MethodReader.create(anyGetter, anyGetter.getReturnType())
+                    .map(reader -> new Getter(reader, false,false, false, false, true, null, null, -1, null))
+                    .orElse(null) :
+                        (anyField != null ? FieldAccessMode.FieldReader.create(anyField, anyField.getGenericType())
+                             .map(reader -> new Getter(reader, false,false, false, false, true, null, null, -1, null))
+                             .orElse(null) : null),
                 accessMode.findAnySetter(clazz),
                 anyField,
                 Map.class.isAssignableFrom(clazz) ? accessMode.findMapAdder(clazz) : null);

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/access/Accessor.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/access/Accessor.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.johnzon.mapper.access;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.AccessibleObject;
+
+class Accessor {
+    private static final MethodHandle TRY_SET_ACCESSIBLE = findTrySetAccessible();
+    
+    private Accessor() {
+    }
+    
+    private static MethodHandle findTrySetAccessible() {
+        try {
+            // The AccessibleObject::trySetAccessible is available from Java 9 and above
+            return MethodHandles
+                .lookup()
+                .findVirtual(AccessibleObject.class, "trySetAccessible", MethodType.methodType(boolean.class));
+        } catch (final IllegalAccessException | NoSuchMethodException ex) {
+            // The method is not available
+            return null;
+        }
+    }
+    
+    public static boolean trySetAccessible(final AccessibleObject obj) {
+        if (!obj.isAccessible()) {
+            if (TRY_SET_ACCESSIBLE != null) {
+                try {
+                    return (boolean)TRY_SET_ACCESSIBLE.invoke(obj);
+                } catch (Throwable ex) {
+                    // Unsuccessful invocation, let's fallback to AccessibleObject::setAccessible()
+                }
+            } 
+            
+            // It may potentially throw InaccessibleObjectException on JDK16+ 
+            obj.setAccessible(true);
+        }
+        
+        return true;
+    }
+}

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/access/BaseAccessMode.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/access/BaseAccessMode.java
@@ -41,6 +41,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -125,7 +126,12 @@ public abstract class BaseAccessMode implements AccessMode {
             for (final Constructor<?> c : clazz.getDeclaredConstructors()) {
                 if (c.getParameterTypes().length == 0) {
                     if (!Modifier.isPublic(c.getModifiers()) && acceptHiddenConstructor) {
-                        c.setAccessible(true);
+                        try {
+                            c.setAccessible(true);
+                        } catch (RuntimeException ex) {
+                            // It may throw InaccessibleObjectException, only available in JDK16+
+                            continue; // skip inaccessible constructors
+                        }
                     }
                     constructor = c;
                     if (!useConstructor) {

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/access/BaseAccessMode.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/access/BaseAccessMode.java
@@ -125,10 +125,7 @@ public abstract class BaseAccessMode implements AccessMode {
             for (final Constructor<?> c : clazz.getDeclaredConstructors()) {
                 if (c.getParameterTypes().length == 0) {
                     if (!Modifier.isPublic(c.getModifiers()) && acceptHiddenConstructor) {
-                        try {
-                            c.setAccessible(true);
-                        } catch (RuntimeException ex) {
-                            // It may throw InaccessibleObjectException, only available in JDK16+
+                        if (!Accessor.trySetAccessible(c)) {
                             continue; // skip inaccessible constructors
                         }
                     }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/access/BaseAccessMode.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/access/BaseAccessMode.java
@@ -41,7 +41,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/access/FieldAccessMode.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/access/FieldAccessMode.java
@@ -24,7 +24,6 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import org.apache.johnzon.mapper.Adapter;
 import org.apache.johnzon.mapper.JohnzonAny;
@@ -47,8 +46,10 @@ public class FieldAccessMode extends BaseAccessMode {
             }
 
             final Field field = f.getValue();
-            FieldReader.create(field, field.getGenericType()).ifPresent(reader ->
-                readers.put(extractKey(field, key), reader));
+            final FieldReader reader = FieldReader.create(field, field.getGenericType());
+            if (reader != null) {
+                readers.put(extractKey(field, key), reader);
+            }
         }
         return readers;
     }
@@ -63,8 +64,10 @@ public class FieldAccessMode extends BaseAccessMode {
             }
 
             final Field field = f.getValue();
-            FieldWriter.create(field, field.getGenericType()).ifPresent(writer ->
-                writers.put(extractKey(field, key), writer));
+            final FieldWriter writer = FieldWriter.create(field, field.getGenericType());
+            if (writer != null) {
+                writers.put(extractKey(field, key), writer);
+            }
         }
         return writers;
     }
@@ -149,16 +152,16 @@ public class FieldAccessMode extends BaseAccessMode {
     }
 
     public static class FieldWriter extends FieldDecoratedType implements Writer {
-        private FieldWriter(final Field field, final Type type) {
+        public FieldWriter(final Field field, final Type type) {
             super(field, type);
         }
         
-        public static Optional<FieldWriter> create(final Field field, final Type type) {
+        public static FieldWriter create(final Field field, final Type type) {
             try {
-                return Optional.of(new FieldWriter(field, type));
+                return new FieldWriter(field, type);
             } catch (RuntimeException ex) {
                 // It may throw InaccessibleObjectException, only available in JDK16+
-                return Optional.empty();
+                return null;
             }
         }
 
@@ -178,16 +181,16 @@ public class FieldAccessMode extends BaseAccessMode {
     }
 
     public static class FieldReader extends FieldDecoratedType  implements Reader {
-        private FieldReader(final Field field, final Type type) {
+        public FieldReader(final Field field, final Type type) {
             super(field, type);
         }
         
-        public static Optional<FieldReader> create(final Field field, final Type type) {
+        public static FieldReader create(final Field field, final Type type) {
             try {
-                return Optional.of(new FieldReader(field, type));
+                return new FieldReader(field, type);
             } catch (RuntimeException ex) {
                 // It may throw InaccessibleObjectException, only available in JDK16+
-                return Optional.empty();
+                return null;
             }
         }
 

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/access/FieldAndMethodAccessMode.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/access/FieldAndMethodAccessMode.java
@@ -120,8 +120,9 @@ public class FieldAndMethodAccessMode extends BaseAccessMode {
             final Reader existing = readers.get(entry.getKey());
             if (existing == null) {
                 if (f != null) { // useful to hold the Field and transient state for example, just as fallback
-                    readers.put(entry.getKey(), new CompositeReader(
-                            entry.getValue(), new FieldAccessMode.FieldReader(f, f.getType())));
+                    FieldAccessMode.FieldReader.create(f, f.getType()).ifPresent(reader ->
+                        readers.put(entry.getKey(), new CompositeReader(
+                            entry.getValue(), reader)));
                 } else {
                     readers.put(entry.getKey(), entry.getValue());
                 }
@@ -215,8 +216,9 @@ public class FieldAndMethodAccessMode extends BaseAccessMode {
             final Writer existing = writers.get(entry.getKey());
             if (existing == null) {
                 if (f != null) { // useful to hold the Field and transient state for example, just as fallback
-                    writers.put(entry.getKey(), new CompositeWriter(
-                            entry.getValue(), new FieldAccessMode.FieldWriter(f, f.getType())));
+                    FieldAccessMode.FieldWriter.create(f, f.getType()).ifPresent(writer ->
+                        writers.put(entry.getKey(), new CompositeWriter(
+                            entry.getValue(), writer)));
                 } else {
                     writers.put(entry.getKey(), entry.getValue());
                 }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/access/FieldAndMethodAccessMode.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/access/FieldAndMethodAccessMode.java
@@ -120,8 +120,8 @@ public class FieldAndMethodAccessMode extends BaseAccessMode {
             final Reader existing = readers.get(entry.getKey());
             if (existing == null) {
                 if (f != null) { // useful to hold the Field and transient state for example, just as fallback
-                    final FieldAccessMode.FieldReader reader = FieldAccessMode.FieldReader.create(f, f.getType());
-                    if (reader != null) {
+                    final FieldAccessMode.FieldReader reader = new FieldAccessMode.FieldReader(f, f.getType());
+                    if (reader.isAccessible()) {
                         readers.put(entry.getKey(), new CompositeReader(entry.getValue(), reader));
                     }
                 } else {
@@ -217,8 +217,8 @@ public class FieldAndMethodAccessMode extends BaseAccessMode {
             final Writer existing = writers.get(entry.getKey());
             if (existing == null) {
                 if (f != null) { // useful to hold the Field and transient state for example, just as fallback
-                    final FieldAccessMode.FieldWriter writer = FieldAccessMode.FieldWriter.create(f, f.getType());
-                    if (writer != null) {
+                    final FieldAccessMode.FieldWriter writer = new FieldAccessMode.FieldWriter(f, f.getType());
+                    if (writer.isAccessible()) {
                         writers.put(entry.getKey(), new CompositeWriter(entry.getValue(), writer));
                     }
                 } else {

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/access/FieldAndMethodAccessMode.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/access/FieldAndMethodAccessMode.java
@@ -120,9 +120,10 @@ public class FieldAndMethodAccessMode extends BaseAccessMode {
             final Reader existing = readers.get(entry.getKey());
             if (existing == null) {
                 if (f != null) { // useful to hold the Field and transient state for example, just as fallback
-                    FieldAccessMode.FieldReader.create(f, f.getType()).ifPresent(reader ->
-                        readers.put(entry.getKey(), new CompositeReader(
-                            entry.getValue(), reader)));
+                    final FieldAccessMode.FieldReader reader = FieldAccessMode.FieldReader.create(f, f.getType());
+                    if (reader != null) {
+                        readers.put(entry.getKey(), new CompositeReader(entry.getValue(), reader));
+                    }
                 } else {
                     readers.put(entry.getKey(), entry.getValue());
                 }
@@ -216,9 +217,10 @@ public class FieldAndMethodAccessMode extends BaseAccessMode {
             final Writer existing = writers.get(entry.getKey());
             if (existing == null) {
                 if (f != null) { // useful to hold the Field and transient state for example, just as fallback
-                    FieldAccessMode.FieldWriter.create(f, f.getType()).ifPresent(writer ->
-                        writers.put(entry.getKey(), new CompositeWriter(
-                            entry.getValue(), writer)));
+                    final FieldAccessMode.FieldWriter writer = FieldAccessMode.FieldWriter.create(f, f.getType());
+                    if (writer != null) {
+                        writers.put(entry.getKey(), new CompositeWriter(entry.getValue(), writer));
+                    }
                 } else {
                     writers.put(entry.getKey(), entry.getValue());
                 }

--- a/johnzon-mapper/src/test/java/org/apache/johnzon/mapper/CircularExceptionTest.java
+++ b/johnzon-mapper/src/test/java/org/apache/johnzon/mapper/CircularExceptionTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertTrue;
 
 public class CircularExceptionTest {
     @Test
-    public void dontStackOverFlow() {
+    public void dontStackOverFlowUsingFieldAccess() {
         final Throwable oopsImVicous = new Exception("circular");
         oopsImVicous.getStackTrace(); // fill it
         oopsImVicous.initCause(new IllegalArgumentException(oopsImVicous));
@@ -33,4 +33,13 @@ public class CircularExceptionTest {
         assertTrue(serialized.contains("\"stackTrace\":[{"));
     }
 
+    @Test
+    public void dontStackOverFlowUsingMethodAccess() {
+        final Throwable oopsImVicous = new Exception("circular");
+        oopsImVicous.getStackTrace(); // fill it
+        oopsImVicous.initCause(new IllegalArgumentException(oopsImVicous));
+        final String serialized = new MapperBuilder().setAccessModeName("method").build().writeObjectAsString(oopsImVicous);
+        assertTrue(serialized.contains("\"message\":\"circular\""));
+        assertTrue(serialized.contains("\"stackTrace\":[{"));
+    }
 }


### PR DESCRIPTION
Since JEP-396 [1] integration into JDK16, the JDK internals become much less accessible. `Johnzon` uses `setAccessible` in several places to relax the visibility rules but it now throws `InaccessibleObjectException` on JDK16 and above (for a number of JDK classes).  For example, we run into following issues with Apache CXF while running JSON-B tests on JDK16/JDK17:

```
java.lang.reflect.InaccessibleObjectException: Unable to make field private int java.util.ArrayList.size accessible: module java.base does not "opens java.util" to unnamed module @567d299b
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:357)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:177)
	at java.base/java.lang.reflect.Field.setAccessible(Field.java:171)
	at org.apache.johnzon.mapper.access.FieldAccessMode$FieldDecoratedType.<init>(FieldAccessMode.java:105)
	at org.apache.johnzon.mapper.access.FieldAccessMode$FieldReader.<init>(FieldAccessMode.java:169)
	at org.apache.johnzon.mapper.access.FieldAccessMode.doFindReaders(FieldAccessMode.java:49)
	at org.apache.johnzon.mapper.access.BaseAccessMode.findReaders(BaseAccessMode.java:82)
	at org.apache.johnzon.mapper.access.FieldAndMethodAccessMode.doFindReaders(FieldAndMethodAccessMode.java:68)
	at org.apache.johnzon.mapper.access.BaseAccessMode.findReaders(BaseAccessMode.java:82)
	at org.apache.johnzon.jsonb.JsonbAccessMode.findReaders(JsonbAccessMode.java:468)
	at org.apache.johnzon.mapper.Mappings.createClassMapping(Mappings.java:475)
	at org.apache.johnzon.mapper.Mappings.doFindOrCreateClassMapping(Mappings.java:437)
	at org.apache.johnzon.mapper.Mappings.findOrCreateClassMapping(Mappings.java:411)
	at org.apache.johnzon.mapper.Mapper.isDeduplicateObjects(Mapper.java:215)
	at org.apache.johnzon.mapper.Mapper.writeObjectWithGenerator(Mapper.java:209)
	at org.apache.johnzon.mapper.Mapper.writeObject(Mapper.java:203)
	at org.apache.johnzon.mapper.Mapper.writeObject(Mapper.java:230)
```

The suggested fix in this PR is to ignore the properties which are not accessible anymore (basically when `setAccessible` ends up with `InaccessibleObjectException` exception). Alternatively, it is still possible to use `--add-opens java.base/java.util=ALL-UNNAMED` but arguably this not considered acceptable. 

[1] https://openjdk.java.net/jeps/396