### PR TITLE
True object and array streaming

### DIFF
--- a/johnzon-core/src/main/java/org/apache/johnzon/core/JohnzonJsonParserImpl.java
+++ b/johnzon-core/src/main/java/org/apache/johnzon/core/JohnzonJsonParserImpl.java
@@ -187,6 +187,10 @@ public abstract class JohnzonJsonParserImpl implements JohnzonJsonParser {
                 return false;
             }
 
+            if (next != Event.KEY_NAME) {
+                throw new IllegalStateException("Expected key name event but got " + next + " instead.");
+            }
+
             String key = parser.getString();
             parser.next();
             JsonValue value = parser.getValue();

--- a/johnzon-core/src/main/java/org/apache/johnzon/core/JohnzonJsonParserImpl.java
+++ b/johnzon-core/src/main/java/org/apache/johnzon/core/JohnzonJsonParserImpl.java
@@ -154,10 +154,11 @@ public abstract class JohnzonJsonParserImpl implements JohnzonJsonParser {
 
                 if (next == Event.END_ARRAY) {
                     return false;
-                } else {
-                    action.accept(getValue());
-                    return true;
                 }
+
+                action.accept(getValue());
+                return true;
+
             }
         };
 
@@ -177,16 +178,17 @@ public abstract class JohnzonJsonParserImpl implements JohnzonJsonParser {
             @Override
             public boolean tryAdvance(Consumer<? super Entry<String, JsonValue>> action) {
                 Event next = next();
-                
+
                 if (next == Event.END_OBJECT) {
                     return false;
-                } else {
-                    String key = getString();
-                    next();
-                    JsonValue value = getValue();
-                    action.accept(new AbstractMap.SimpleImmutableEntry<>(key, value));
-                    return true;
                 }
+
+                String key = getString();
+                next();
+                JsonValue value = getValue();
+                action.accept(new AbstractMap.SimpleImmutableEntry<>(key, value));
+                return true;
+
             }
         };
 

--- a/johnzon-core/src/main/java/org/apache/johnzon/core/JohnzonJsonParserImpl.java
+++ b/johnzon-core/src/main/java/org/apache/johnzon/core/JohnzonJsonParserImpl.java
@@ -17,9 +17,15 @@
 package org.apache.johnzon.core;
 
 
+import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import javax.json.JsonArray;
 import javax.json.JsonObject;
@@ -134,18 +140,57 @@ public abstract class JohnzonJsonParserImpl implements JohnzonJsonParser {
 
     @Override
     public Stream<JsonValue> getArrayStream() {
-        //X TODO this implementation is very simplistic
-        //X I find it unintuitive what the spec intends here
-        //X we probably need to improve this
-        return getArray().stream();
+        Event current = current();
+        if (current != Event.START_ARRAY) {
+            throw new IllegalStateException(current + " doesn't support getArrayStream()");
+        }
+
+        Spliterator<JsonValue> arraySpliterator = new Spliterators.AbstractSpliterator<JsonValue>(
+                Long.MAX_VALUE, Spliterator.IMMUTABLE | Spliterator.NONNULL | Spliterator.ORDERED) {
+
+            @Override
+            public boolean tryAdvance(Consumer<? super JsonValue> action) {
+                Event next = next();
+
+                if (next == Event.END_ARRAY) {
+                    return false;
+                } else {
+                    action.accept(getValue());
+                    return true;
+                }
+            }
+        };
+
+        return StreamSupport.stream(arraySpliterator, false);
     }
 
     @Override
     public Stream<Map.Entry<String, JsonValue>> getObjectStream() {
-        //X TODO this implementation is very simplistic
-        //X I find it unintuitive what the spec intends here
-        //X we probably need to improve this
-        return getObject().entrySet().stream();
+        Event current = current();
+        if (current != Event.START_OBJECT) {
+            throw new IllegalStateException(current + " doesn't support getObjectStream()");
+        }
+
+        Spliterator<Map.Entry<String, JsonValue>> objectSpliterator = new Spliterators.AbstractSpliterator<Map.Entry<String,JsonValue>>(
+                Long.MAX_VALUE, Spliterator.IMMUTABLE | Spliterator.NONNULL | Spliterator.ORDERED) {
+
+            @Override
+            public boolean tryAdvance(Consumer<? super Entry<String, JsonValue>> action) {
+                Event next = next();
+                
+                if (next == Event.END_OBJECT) {
+                    return false;
+                } else {
+                    String key = getString();
+                    next();
+                    JsonValue value = getValue();
+                    action.accept(new AbstractMap.SimpleImmutableEntry<>(key, value));
+                    return true;
+                }
+            }
+        };
+
+        return StreamSupport.stream(objectSpliterator, false);
     }
 
     @Override

--- a/johnzon-core/src/test/java/org/apache/johnzon/core/JsonParserStreamingTest.java
+++ b/johnzon-core/src/test/java/org/apache/johnzon/core/JsonParserStreamingTest.java
@@ -35,6 +35,7 @@ import javax.json.Json;
 import javax.json.JsonNumber;
 import javax.json.JsonString;
 import javax.json.stream.JsonParser;
+import javax.json.stream.JsonParsingException;
 
 import org.junit.Test;
 
@@ -141,6 +142,17 @@ public class JsonParserStreamingTest {
         assertEquals(21, sum);
     }
 
+    @Test(expected = JsonParsingException.class)
+    public void testParseErrorInGetArrayStream() {
+        StringReader sr = new StringReader("[\"this is\":\"not an object\"]");
+        JsonParser jsonParser = Json.createParser(sr);
+
+        JsonParser.Event firstEvent = jsonParser.next();
+        assertEquals(JsonParser.Event.START_ARRAY, firstEvent);
+
+        jsonParser.getArrayStream().forEach(dummy -> {});
+    }
+
     @Test
     public void testGetObjectStream() {
         StringReader sr = new StringReader("{\"foo\":\"bar\",\"baz\":\"quux\",\"something\":\"else\"}");
@@ -158,4 +170,16 @@ public class JsonParserStreamingTest {
         expectedMappings.put("something", "else");
         assertEquals(expectedMappings, mappings);
     }
+
+    @Test(expected = JsonParsingException.class)
+    public void testParseErrorInGetObjectStream() {
+        StringReader sr = new StringReader("{42}");
+        JsonParser jsonParser = Json.createParser(sr);
+
+        JsonParser.Event firstEvent = jsonParser.next();
+        assertEquals(JsonParser.Event.START_OBJECT, firstEvent);
+
+        jsonParser.getObjectStream().forEach(dummy -> {});
+    }
+
 }


### PR DESCRIPTION
As the comments say, `getArrayStream()` and `getObjectStream()` were very simplistic and didn't conform to the spirit of the specification, which requires lazy loading from the underlying stream.

Now these methods should behave lazily, only keeping the minimal amount of data in memory that's necessary for the stream.