### PR TITLE
update maven plugins

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,10 +22,7 @@ jobs:
           distribution: ${{ matrix.dist }}
           cache: 'maven'
 
-      - name: Maven Package
+      - name: Maven Verify
         env:
           MAVEN_OPTS: -Dmaven.artifact.threads=64
-        run: mvn -V package --no-transfer-progress
-
-      #- name: Maven javadoc
-      #  run: mvn javadoc:javadoc -Ddoclint=all --no-transfer-progress
+        run: mvn -V verify --no-transfer-progress

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,7 +22,7 @@ jobs:
           distribution: ${{ matrix.dist }}
           cache: 'maven'
 
-      - name: Maven Verify
+      - name: Maven Package
         env:
           MAVEN_OPTS: -Dmaven.artifact.threads=64
-        run: mvn -V verify --no-transfer-progress
+        run: mvn -V package --no-transfer-progress

--- a/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/JsonbRecordTest.java
+++ b/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/JsonbRecordTest.java
@@ -34,18 +34,18 @@ public class JsonbRecordTest {
 
     @Test
     public void roundTrip() {
-        final JsonbRecord ref = new JsonbRecord(119, "Santa");
+        final Record ref = new Record(119, "Santa");
         final String expectedJson = "{\"_name\":\"Santa\",\"age\":119}";
         assertEquals(expectedJson, jsonb.toJson(ref));
-        assertEquals(ref, jsonb.fromJson(expectedJson, JsonbRecord.class));
+        assertEquals(ref, jsonb.fromJson(expectedJson, Record.class));
     }
 
     @JohnzonRecord
-    public static class JsonbRecord {
+    public static class Record {
         private final int age;
         private final String name;
 
-        public JsonbRecord(@JohnzonRecord.Name("age") final int age,
+        public Record(@JohnzonRecord.Name("age") final int age,
                            @JohnzonRecord.Name("name") @JsonbProperty("_name") final String name) { // simulate custom constructor
             this.age = age;
             this.name = name;
@@ -61,7 +61,7 @@ public class JsonbRecordTest {
 
         @Override
         public String toString() {
-            return "JsonbRecord{" +
+            return "Record{" +
                     "age=" + age +
                     ", name='" + name + '\'' +
                     '}';
@@ -75,8 +75,8 @@ public class JsonbRecordTest {
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-            final JsonbRecord jsonbRecord = JsonbRecord.class.cast(o);
-            return age == jsonbRecord.age && Objects.equals(name, jsonbRecord.name);
+            final Record record = Record.class.cast(o);
+            return age == record.age && Objects.equals(name, record.name);
         }
 
         @Override

--- a/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/JsonbRecordTest.java
+++ b/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/JsonbRecordTest.java
@@ -34,19 +34,19 @@ public class JsonbRecordTest {
 
     @Test
     public void roundTrip() {
-        final Record ref = new Record(119, "Santa");
+        final JsonbRecord ref = new JsonbRecord(119, "Santa");
         final String expectedJson = "{\"_name\":\"Santa\",\"age\":119}";
         assertEquals(expectedJson, jsonb.toJson(ref));
-        assertEquals(ref, jsonb.fromJson(expectedJson, Record.class));
+        assertEquals(ref, jsonb.fromJson(expectedJson, JsonbRecord.class));
     }
 
     @JohnzonRecord
-    public static class Record {
+    public static class JsonbRecord {
         private final int age;
         private final String name;
 
-        public Record(@JohnzonRecord.Name("age") final int age,
-                      @JohnzonRecord.Name("name") @JsonbProperty("_name") final String name) { // simulate custom constructor
+        public JsonbRecord(@JohnzonRecord.Name("age") final int age,
+                           @JohnzonRecord.Name("name") @JsonbProperty("_name") final String name) { // simulate custom constructor
             this.age = age;
             this.name = name;
         }
@@ -61,7 +61,7 @@ public class JsonbRecordTest {
 
         @Override
         public String toString() {
-            return "Record{" +
+            return "JsonbRecord{" +
                     "age=" + age +
                     ", name='" + name + '\'' +
                     '}';
@@ -75,8 +75,8 @@ public class JsonbRecordTest {
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-            final Record record = Record.class.cast(o);
-            return age == record.age && Objects.equals(name, record.name);
+            final JsonbRecord jsonbRecord = JsonbRecord.class.cast(o);
+            return age == jsonbRecord.age && Objects.equals(name, jsonbRecord.name);
         }
 
         @Override

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Adapter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Adapter.java
@@ -29,25 +29,23 @@ package org.apache.johnzon.mapper;
  * Our {@code Mapper} should treat it as a {@code java.util.Date}.
  * For doing so we create a {@code DateHolderAdapter} like the following example shows:
  * <pre>
- * {@code
- * public static class DateHolderAdapter implements Adapter<DateHolder, Date> {
- *     @Override
+ * {@code public static class DateHolderAdapter implements Adapter<DateHolder, Date>} {
+ *     {@code @Override}
  *     public DateHolder to(Date date) {
  *         DateHolder dh = new DateHolder(date.getTime());
  *         return dh;
  *     }
  *
- *     @Override
+ *     {@code @Override}
  *     public Date from(DateHolder dateHolder) {
  *        return new Date(dateHolder.getDate());
  *     }
- * }
  * }
  * </pre>
  *
  * Consider a POJO has a DateHolder.
  * When serialising the {@code Mapper} will first use the {@code DateHolderAdapter#from(DateHolder)} and from there to JSON.
- * When reading JSON the {@code to(Date}} method will be used.
+ * When reading JSON the {@code to(Date)} method will be used.
  *
  * @param <POJO_TYPE> The Java type in the POJO (Plain Old Java Object)
  * @param <JSON_TYPE> The Java Type which will be used to transform to JSON.

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/JohnzonRecord.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/JohnzonRecord.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
 /**
  * Forces method named as properties to be used as getters (String foo() will match the attribute foo).
  * Also enables a constructor with all properties even if not marked as @ConstructorProperties or equivalent.
- * It simulates java >= 14 record style.
+ * It simulates Java 14+ records.
  */
 @Target({ TYPE })
 @Retention(RUNTIME)

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/internal/JsonPointerTracker.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/internal/JsonPointerTracker.java
@@ -45,7 +45,7 @@ public class JsonPointerTracker {
     /**
      * For Arrays and Lists.
      *
-     * @param jsonPointer
+     * @param jsonPointer the json node
      * @param i           current counter number
      */
     public JsonPointerTracker(JsonPointerTracker jsonPointer, int i) {

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/util/BeanUtil.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/util/BeanUtil.java
@@ -30,7 +30,7 @@ public final class BeanUtil {
     /**
      * Calculate the name of a getter based on the name of it's field and the type
      *
-     * @param fieldName
+     * @param fieldName of the field
      * @param type      of the field
      * @return "get" or "is" method name for the field
      */
@@ -44,7 +44,7 @@ public final class BeanUtil {
     /**
      * Calculate the name of a setter based on the name of it's field
      *
-     * @param fieldName
+     * @param fieldName of the field
      * @return "set" method name for the field
      */
     public static String setterName(String fieldName) {
@@ -64,9 +64,9 @@ public final class BeanUtil {
     }
 
     /**
-     * capitalize according to java beans specification.
-     * That is start the given field with a lower case, but only if the 2nd char is not also an uppercase character
-     * Enabled -> enabled, but URL will remain URL.
+     * decapitalize according to java beans specification.
+     * That is start the given field with a lower case, but only if the 2nd char is not also an uppercase character.
+     * eg; "Enabled" will become "enabled", but "URL" will remain "URL".
      */
     public static String decapitalize(String name) {
         if (name == null || name.length() == 0) {

--- a/johnzon-maven-plugin/pom.xml
+++ b/johnzon-maven-plugin/pom.xml
@@ -31,7 +31,7 @@
   <packaging>maven-plugin</packaging>
 
   <properties>
-    <maven.version>3.0.5</maven.version>
+    <maven.version>3.6.0</maven.version>
   </properties>
 
 
@@ -68,16 +68,36 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
       <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-settings</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.4</version>
+      <version>${maven.version}</version>
     </dependency>
   </dependencies>
 
@@ -86,7 +106,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.4</version>
+        <version>3.7.0</version>
         <executions>
           <execution>
             <id>mojo-descriptor</id>

--- a/johnzon-osgi/pom.xml
+++ b/johnzon-osgi/pom.xml
@@ -29,6 +29,10 @@
   <name>Johnzon :: Support for OSGI Jaxrs Whiteboard</name>
   <packaging>bundle</packaging>
 
+  <properties>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.aries.component-dsl</groupId>

--- a/johnzon-websocket/pom.xml
+++ b/johnzon-websocket/pom.xml
@@ -145,13 +145,6 @@
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -183,10 +183,10 @@
           <version>${checkstyle.version}</version>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>findbugs-maven-plugin</artifactId>
-          <!-- todo: migrate to spotbugs-maven-plugin as the findbugs plugin is no longer maintained -->
-          <version>3.0.5</version>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <!-- todo: Update spotbugs-maven-plugin to v4: https://spotbugs.readthedocs.io/en/stable/migration.html -->
+          <version>3.1.12.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -526,11 +526,11 @@
         <!-- Version defined in Apache parent pom -->
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
         <configuration>
           <xmlOutput>true</xmlOutput>
-          <!-- Optional directory to put findbugs xdoc xml report -->
+          <!-- Optional directory to put spotbugs (previously findbugs) xdoc xml report -->
           <xmlOutputDirectory>target/site</xmlOutputDirectory>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -33,22 +33,25 @@
   <name>Apache Johnzon</name>
   <description>Apache Johnzon is an implementation of JSR-353 (JavaTM API for JSON Processing).</description>
   <inceptionYear>2014</inceptionYear>
-  <url>http://johnzon.apache.org</url>
+  <url>https://johnzon.apache.org</url>
 
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <project.build.outputTimestamp>10</project.build.outputTimestamp>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+
     <geronimo-jsonp.version>1.5</geronimo-jsonp.version>
     <geronimo-jsonb.version>1.4</geronimo-jsonb.version>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.build.outputTimestamp>10</project.build.outputTimestamp>
     <johnzon.site.url>https://svn.apache.org/repos/asf/johnzon/site/publish/</johnzon.site.url>
     <pubsub.url>scm:svn:${johnzon.site.url}</pubsub.url>
     <staging.directory>${project.build.directory}/site</staging.directory>
     <felix.plugin.version>5.1.8</felix.plugin.version>
     <bnd.version.policy>[$(version;==;$(@)),$(version;+;$(@)))</bnd.version.policy>
     <bnd.version>6.1.0</bnd.version>
-    <java-compile.version>1.8</java-compile.version>
     <cxf.version>3.4.1</cxf.version>
-    <checkstyle.version>2.15</checkstyle.version> <!-- checkstyle > 2.15 version do not support java 6 -->
+    <checkstyle.version>3.0.0</checkstyle.version> <!-- Increasing checkstyle to 3.1 or above will require changes to the checkstyleRules -->
     <!-- JVM values for surefire plugin -->
     <surefire.jvm.params>-Xms1024m -Xmx2048m -Dfile.encoding=UTF-8</surefire.jvm.params>
     <owb.version>2.0.23</owb.version>
@@ -78,6 +81,18 @@
         <version>${geronimo-jsonb.version}</version>
         <scope>provided</scope>
       </dependency>
+      <dependency>
+        <groupId>org.apache.geronimo.specs</groupId>
+        <artifactId>geronimo-json_1.1_spec</artifactId>
+        <version>${geronimo-jsonp.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.2</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -85,14 +100,12 @@
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-json_1.1_spec</artifactId>
-      <version>${geronimo-jsonp.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -103,7 +116,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.2.3</version>
+          <!-- Version defined in Apache parent pom -->
           <executions>
             <execution>
               <id>jakarta</id>
@@ -164,16 +177,50 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <version>${checkstyle.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>findbugs-maven-plugin</artifactId>
+          <!-- todo: migrate to spotbugs-maven-plugin as the findbugs plugin is no longer maintained -->
+          <version>3.0.5</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-pmd-plugin</artifactId>
+          <version>3.19.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>2.13.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>taglist-maven-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-changelog-plugin</artifactId>
+          <version>2.3</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-changes-plugin</artifactId>
+          <version>2.12.1</version>
+        </plugin>
       </plugins>
     </pluginManagement>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>${java-compile.version}</source>
-          <target>${java-compile.version}</target>
-          <encoding>UTF-8</encoding>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
         </configuration>
@@ -239,7 +286,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.5.1</version>
+        <!-- Version defined in Apache parent pom -->
         <configuration>
           <stagingDirectory>${staging.directory}</stagingDirectory>
         </configuration>
@@ -260,7 +307,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>${checkstyle.version}</version>
         <executions>
           <execution>
             <id>verify-style</id>
@@ -375,7 +421,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.2.0</version>
+        <!-- Version defined in Apache parent pom -->
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -387,8 +433,7 @@
               <detectJavaApiLink>false</detectJavaApiLink>
               <detectLinks>false</detectLinks>
               <detectOfflineLinks>false</detectOfflineLinks>
-              <doclint>none</doclint>
-              <source>8</source>
+              <doclint>all,-missing</doclint>
             </configuration>
           </execution>
         </executions>
@@ -397,7 +442,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <!-- Version defined in Apache parent pom -->
         <configuration>
           <argLine>${surefire.jvm.params}</argLine>
           <trimStackTrace>false</trimStackTrace>
@@ -412,27 +457,6 @@
           <pushChanges>false</pushChanges>
           <localCheckout>true</localCheckout>
           <autoVersionSubmodules>true</autoVersionSubmodules>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.6</version>
-        <configuration>
-          <instrumentation>
-            <ignores>
-              <ignore>org.apache.johnzon.maven.*</ignore>
-            </ignores>
-            <excludes>
-              <exclude>org/apache/johnzon/**/*Mojo*.class</exclude>
-              <exclude>org/apache/johnzon/**/*Test.class</exclude>
-            </excludes>
-          </instrumentation>
-          <formats>
-            <format>xml</format>
-          </formats>
-          <aggregate>true</aggregate>
         </configuration>
       </plugin>
 
@@ -470,25 +494,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M2</version>
-        <executions>
-          <execution>
-            <id>enforce-versions</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireMavenVersion>
-                  <version>[3.3,)</version>
-                </requireMavenVersion>
-                <requireJavaVersion>
-                  <version>[${java-compile.version},)</version>
-                </requireJavaVersion>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
+        <!-- Version (and configuration) defined in Apache parent pom -->
       </plugin>
     </plugins>
   </build>
@@ -517,12 +523,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.5.1</version>
+        <!-- Version defined in Apache parent pom -->
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.4</version>
         <configuration>
           <xmlOutput>true</xmlOutput>
           <!-- Optional directory to put findbugs xdoc xml report -->
@@ -532,12 +537,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.6</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.9</version>
+        <!-- Version defined in Apache parent pom -->
         <configuration>
           <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
         </configuration>
@@ -545,7 +549,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.3</version>
         <configuration>
           <notimestamp>true</notimestamp>
           <show>private</show>
@@ -567,29 +570,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>2.19.1</version>
+        <!-- Version defined in Apache parent pom -->
         <configuration>
           <argLine>${surefire.jvm.params}</argLine>
-          <aggregate>true</aggregate>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.6</version>
-        <configuration>
-          <instrumentation>
-            <ignores>
-              <ignore>org.apache.johnzon.maven.*</ignore>
-            </ignores>
-            <excludes>
-              <exclude>org/apache/johnzon/**/*Mojo*.class</exclude>
-              <exclude>org/apache/johnzon/**/*Test.class</exclude>
-            </excludes>
-          </instrumentation>
-          <formats>
-            <format>html</format>
-          </formats>
           <aggregate>true</aggregate>
         </configuration>
       </plugin>
@@ -608,7 +591,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.1</version>
         <reportSets>
           <reportSet>
             <reports>
@@ -622,7 +604,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>taglist-maven-plugin</artifactId>
-        <version>2.4</version>
         <configuration>
           <tags>
             <tag>TODO</tag>
@@ -636,7 +617,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-changelog-plugin</artifactId>
-        <version>2.3</version>
         <configuration>
           <type>range</type>
           <range>30</range>
@@ -646,7 +626,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-changes-plugin</artifactId>
-        <version>2.11</version>
         <configuration>
           <useJql>true</useJql>
           <columnNames>Type,Key,Summary,Assignee,Status,Resolution,Created</columnNames>
@@ -795,16 +774,6 @@
   </contributors>
 
   <profiles>
-    <profile>
-      <id>doclint-java8-disable</id>
-      <activation>
-        <jdk>[1.8,)</jdk>
-      </activation>
-      <properties>
-        <checkstyle.version>2.17</checkstyle.version>
-      </properties>
-    </profile>
-
     <profile>
         <id>jdk9+</id>
         <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -115,8 +115,48 @@
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.10.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.2.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.4.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.0.0-M7</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-report-plugin</artifactId>
+          <version>3.0.0-M7</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.12.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>3.0.0-M6</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <!-- Version defined in Apache parent pom -->
+          <version>3.4.1</version>
           <executions>
             <execution>
               <id>jakarta</id>
@@ -194,6 +234,11 @@
           <version>3.19.0</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>3.4.1</version>
+        </plugin>
+        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
           <version>2.13.0</version>
@@ -213,6 +258,12 @@
           <artifactId>maven-changes-plugin</artifactId>
           <version>2.12.1</version>
         </plugin>
+
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>${felix.plugin.version}</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -221,6 +272,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
+          <encoding>${project.build.sourceEncoding}</encoding>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
         </configuration>
@@ -286,7 +340,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <!-- Version defined in Apache parent pom -->
         <configuration>
           <stagingDirectory>${staging.directory}</stagingDirectory>
         </configuration>
@@ -421,7 +474,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <!-- Version defined in Apache parent pom -->
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -434,6 +486,7 @@
               <detectLinks>false</detectLinks>
               <detectOfflineLinks>false</detectOfflineLinks>
               <doclint>all,-missing</doclint>
+              <source>${maven.compiler.source}</source>
             </configuration>
           </execution>
         </executions>
@@ -442,7 +495,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <!-- Version defined in Apache parent pom -->
         <configuration>
           <argLine>${surefire.jvm.params}</argLine>
           <trimStackTrace>false</trimStackTrace>
@@ -471,7 +523,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>${felix.plugin.version}</version>
         <inherited>true</inherited>
         <extensions>true</extensions>
         <configuration>
@@ -494,7 +545,24 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <!-- Version (and configuration) defined in Apache parent pom -->
+        <executions>
+          <execution>
+            <id>enforce-versions</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.3,)</version>
+                </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>[${maven.compiler.target},)</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
@@ -523,7 +591,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <!-- Version defined in Apache parent pom -->
       </plugin>
       <plugin>
         <groupId>com.github.spotbugs</groupId>
@@ -541,7 +608,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <!-- Version defined in Apache parent pom -->
         <configuration>
           <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
         </configuration>
@@ -570,7 +636,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-report-plugin</artifactId>
-        <!-- Version defined in Apache parent pom -->
         <configuration>
           <argLine>${surefire.jvm.params}</argLine>
           <aggregate>true</aggregate>


### PR DESCRIPTION
building on the work done by @hboutemy in PR #93, and the javadoc fixes in PR #95, these changes fix some outstanding errors with Javadoc and aim to improve the build by making sure that maven plugins are defined in the root johnzon pom within the _pluginManagement_ section. 

In the case of the cobertura plugin, I've removed it entirely as it's been defunct for some time and Jacoco should be used instead. I've swapped the now dead findbugs plugin for spotbugs (more changes need to use v4 though). The checkstyle plugin needs further changes which can be in a future PR. I've also enabled javadoc linting as it no longer fails.