### PR TITLE
TCKs in github actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,15 +2,17 @@ name: Maven
 
 on: [push, pull_request]
 
+env:
+  MAVEN_OPTS: -Dmaven.artifact.threads=64
+
 jobs:
   build:
     name: Test with Java ${{ matrix.jdk }}
-    #runs-on: ${{ matrix.os }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ '11', '17', '19' ]
+        jdk: [ '11', '17', '20' ]
         dist: [ 'zulu' ]
 
     steps:
@@ -23,6 +25,27 @@ jobs:
           cache: 'maven'
 
       - name: Maven Package
-        env:
-          MAVEN_OPTS: -Dmaven.artifact.threads=64
-        run: mvn -V package --no-transfer-progress
+        run: mvn -V --no-transfer-progress package
+
+  tck:
+    name: Run ${{ matrix.spec }} TCK with Java ${{ matrix.jdk }}-${{ matrix.dist }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [ '11', '17', '20' ]
+        dist: [ 'zulu' ]
+        spec: ['jsonp', 'jsonb']
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK ${{ matrix.jdk }}
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: ${{ matrix.dist }}
+          cache: 'maven'
+
+      - name: Maven Verify TCK
+        run: mvn -V --no-transfer-progress verify --also-make --projects tck/${{ matrix.spec }} -Ptck-${{ matrix.spec }}

--- a/tck/jsonb/pom.xml
+++ b/tck/jsonb/pom.xml
@@ -122,6 +122,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${surefire.version}</version>
         <configuration>
+          <skip>${tck.skipJsonb}</skip>
           <reuseForks>false</reuseForks>
           <forkCount>1</forkCount>
           <dependenciesToScan>

--- a/tck/jsonp/pom.xml
+++ b/tck/jsonp/pom.xml
@@ -123,6 +123,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.0.0-M7</version>
         <configuration>
+          <skip>${tck.skipJsonp}</skip>
           <reuseForks>false</reuseForks>
           <forkCount>1</forkCount>
           <dependenciesToScan>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -34,4 +34,26 @@
     <module>jsonp</module>
   </modules>
 
+  <profiles>
+    <profile>
+      <id>tck-jsonb</id>
+
+      <properties>
+        <tck.skipJsonb>false</tck.skipJsonb>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>tck-jsonp</id>
+
+      <properties>
+        <tck.skipJsonp>false</tck.skipJsonp>
+      </properties>
+    </profile>
+  </profiles>
+
+  <properties>
+    <tck.skipJsonp>true</tck.skipJsonp>
+    <tck.skipJsonb>true</tck.skipJsonb>
+  </properties>
 </project>


### PR DESCRIPTION
- Disables running TCKs by default, introduces `tck-jsonb` and `tck-jsonp` profiles to do so
- Seperately runs JSON-P and JSON-P TCKs in GitHub Actions as part of CI (without failing the CI run if TCKs are failing. Might change this in the future when johnzon is passing all TCKs)