### PR TITLE
JOHNZON-398: full JPMS support via module-info.java mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+Apache Johnzon
+==============
+
+[![Maven](https://github.com/apache/johnzon/actions/workflows/maven.yml/badge.svg)](https://github.com/apache/johnzon/actions/workflows/maven.yml)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.johnzon/johnzon-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.johnzon/johnzon-core)
+[![Javadocs](https://www.javadoc.io/badge/org.apache.johnzon/johnzon-core.svg)](https://www.javadoc.io/doc/org.apache.johnzon/johnzon-core)
+
+Apache Johnzon is a project providing an implementation of JsonProcessing (aka JSR-353) and a set of useful extension for this specification like an Object mapper, some JAX-RS providers and a WebSocket module provides a basic integration with Java WebSocket API (JSR-356).
+
+See the main website: [johnzon.apache.org](https://johnzon.apache.org)
+
+The project Jira: [issues.apache.org/jira/projects/JOHNZON](https://issues.apache.org/jira/projects/JOHNZON).
+
+Artifacts are published to [maven central](https://central.sonatype.dev/publisher/org.apache.johnzon).
+
+```xml
+    <dependency>
+        <groupId>org.apache.johnzon</groupId>
+        <artifactId>johnzon-core</artifactId>
+        <version>${johnzon.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.johnzon</groupId>
+        <artifactId>johnzon-jsonp-strict</artifactId>
+        <version>${johnzon.version}</version>
+    </dependency>
+```

--- a/johnzon-core/pom.xml
+++ b/johnzon-core/pom.xml
@@ -40,7 +40,6 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>
           <instructions>
-            <Automatic-Module-Name>org.apache.johnzon.core</Automatic-Module-Name>
             <Require-Capability>osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
             <Provide-Capability>osgi.serviceloader;osgi.serviceloader=jakarta.json.spi.JsonProvider</Provide-Capability>
           </instructions>

--- a/johnzon-core/src/main/java/module-info.java
+++ b/johnzon-core/src/main/java/module-info.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module org.apache.johnzon.core {
+
+    requires java.logging;
+
+    requires transitive jakarta.json;
+
+    exports org.apache.johnzon.core;
+    exports org.apache.johnzon.core.io;
+    exports org.apache.johnzon.core.util;
+
+    // required due to reflection used in other packages
+    opens org.apache.johnzon.core to org.apache.johnzon.mapper, org.apache.johnzon.jaxrs, org.apache.johnzon.jsonb;
+}

--- a/johnzon-jaxrs/pom.xml
+++ b/johnzon-jaxrs/pom.xml
@@ -66,15 +66,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Automatic-Module-Name>org.apache.johnzon.jaxrs</Automatic-Module-Name>
-          </instructions>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>

--- a/johnzon-jaxrs/src/main/java/module-info.java
+++ b/johnzon-jaxrs/src/main/java/module-info.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module org.apache.johnzon.jaxrs {
+    requires java.logging;
+
+    requires transitive jakarta.json;
+    requires transitive jakarta.ws.rs;
+    requires transitive java.xml;
+
+    requires org.apache.johnzon.mapper;
+
+    exports org.apache.johnzon.jaxrs;
+    exports org.apache.johnzon.jaxrs.xml;
+}

--- a/johnzon-json-extras/src/main/java/module-info.java
+++ b/johnzon-json-extras/src/main/java/module-info.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module org.apache.johnzon.jsonb.extras {
+
+    requires transitive jakarta.json;
+    requires transitive jakarta.json.bind;
+
+    exports org.apache.johnzon.jsonb.extras.polymorphism;
+}

--- a/johnzon-jsonb/pom.xml
+++ b/johnzon-jsonb/pom.xml
@@ -37,21 +37,18 @@
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
-      <version>2.1.1</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
-      <version>3.1.0</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>jakarta.enterprise</groupId>
       <artifactId>jakarta.enterprise.cdi-api</artifactId>
-      <version>4.0.1</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
@@ -88,14 +85,14 @@
     <dependency>
       <groupId>jakarta.interceptor</groupId>
       <artifactId>jakarta.interceptor-api</artifactId>
-      <version>2.1.0</version>
-      <scope>test</scope>
+      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>jakarta.inject</groupId>
       <artifactId>jakarta.inject-api</artifactId>
-      <version>2.0.1</version>
-      <scope>test</scope>
+      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.openwebbeans</groupId>
@@ -144,9 +141,8 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>
           <instructions>
-            <Automatic-Module-Name>org.apache.johnzon.jsonb</Automatic-Module-Name>
             <Import-Package>
-              javax.ws.rs.*;resolution:=optional,
+              jakarta.ws.rs.*;resolution:=optional,
               *
             </Import-Package>
             <Require-Capability>

--- a/johnzon-jsonb/src/main/java/module-info.java
+++ b/johnzon-jsonb/src/main/java/module-info.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module org.apache.johnzon.jsonb {
+
+    requires org.apache.johnzon.core;
+    requires org.apache.johnzon.mapper;
+
+    requires java.logging;
+
+    requires transitive jakarta.cdi;
+    requires transitive jakarta.inject;
+    requires transitive jakarta.interceptor;
+    requires transitive jakarta.json;
+    requires transitive jakarta.json.bind;
+    requires transitive jakarta.ws.rs;
+
+    exports org.apache.johnzon.jsonb;
+    exports org.apache.johnzon.jsonb.adapter;
+    exports org.apache.johnzon.jsonb.api.experimental;
+    exports org.apache.johnzon.jsonb.cdi;
+    exports org.apache.johnzon.jsonb.converter;
+    exports org.apache.johnzon.jsonb.extension;
+    exports org.apache.johnzon.jsonb.factory;
+    exports org.apache.johnzon.jsonb.order;
+    exports org.apache.johnzon.jsonb.polymorphism;
+    exports org.apache.johnzon.jsonb.reflect;
+    exports org.apache.johnzon.jsonb.serializer;
+    exports org.apache.johnzon.jsonb.spi;
+
+    provides jakarta.enterprise.inject.spi.Extension with org.apache.johnzon.jsonb.cdi.JohnzonCdiExtension;
+    provides jakarta.json.bind.spi.JsonbProvider with org.apache.johnzon.jsonb.JohnzonProvider;
+}

--- a/johnzon-jsonlogic/pom.xml
+++ b/johnzon-jsonlogic/pom.xml
@@ -41,15 +41,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Automatic-Module-Name>org.apache.johnzon.jsonlogic</Automatic-Module-Name>
-          </instructions>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>

--- a/johnzon-jsonlogic/src/main/java/module-info.java
+++ b/johnzon-jsonlogic/src/main/java/module-info.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module org.apache.johnzon.jsonlogic {
+    requires transitive jakarta.json;
+
+    exports org.apache.johnzon.jsonlogic;
+    exports org.apache.johnzon.jsonlogic.spi;
+}

--- a/johnzon-jsonschema/pom.xml
+++ b/johnzon-jsonschema/pom.xml
@@ -55,15 +55,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Automatic-Module-Name>org.apache.johnzon.jsonschema</Automatic-Module-Name>
-          </instructions>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>

--- a/johnzon-jsonschema/src/main/java/module-info.java
+++ b/johnzon-jsonschema/src/main/java/module-info.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module org.apache.johnzon.jsonschema {
+
+    requires transitive jakarta.json;
+    requires transitive jakarta.json.bind;
+
+    requires transitive java.scripting;
+    requires transitive org.jruby.jcodings;
+    requires transitive org.jruby.joni;
+
+    exports org.apache.johnzon.jsonschema;
+    exports org.apache.johnzon.jsonschema.generator;
+    exports org.apache.johnzon.jsonschema.regex;
+    exports org.apache.johnzon.jsonschema.spi;
+    exports org.apache.johnzon.jsonschema.spi.builtin;
+}

--- a/johnzon-mapper/pom.xml
+++ b/johnzon-mapper/pom.xml
@@ -38,13 +38,15 @@
     <dependency>
       <groupId>jakarta.persistence</groupId>
       <artifactId>jakarta.persistence-api</artifactId>
-      <version>3.1.0</version>
+      <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>jakarta.transaction</groupId>
       <artifactId>jakarta.transaction-api</artifactId>
-      <version>2.0.1</version>
+      <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.openjpa</groupId>
       <artifactId>openjpa</artifactId>
@@ -78,7 +80,6 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>
           <instructions>
-            <Automatic-Module-Name>org.apache.johnzon.mapper</Automatic-Module-Name>
             <Export-Package>{local-packages};-split-package:=error,org.apache.johnzon.mapper.internal</Export-Package>
           </instructions>
         </configuration>

--- a/johnzon-mapper/src/main/java/module-info.java
+++ b/johnzon-mapper/src/main/java/module-info.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module org.apache.johnzon.mapper {
+
+    requires org.apache.johnzon.core;
+    requires java.desktop; // for java.beans
+
+    requires jakarta.json;
+
+    exports org.apache.johnzon.mapper;
+    exports org.apache.johnzon.mapper.access;
+    exports org.apache.johnzon.mapper.converter;
+    exports org.apache.johnzon.mapper.jsonp;
+    exports org.apache.johnzon.mapper.map;
+    exports org.apache.johnzon.mapper.reflection;
+    exports org.apache.johnzon.mapper.util;
+
+    exports org.apache.johnzon.mapper.internal to org.apache.johnzon.jaxrs, org.apache.johnzon.jsonb;
+}

--- a/johnzon-websocket/pom.xml
+++ b/johnzon-websocket/pom.xml
@@ -148,18 +148,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <useModulePath>false</useModulePath>
           <systemPropertyVariables>
             <openejb.deployer.repository>https://repo1.maven.org/maven2/</openejb.deployer.repository>
           </systemPropertyVariables>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Automatic-Module-Name>org.apache.johnzon.websocket</Automatic-Module-Name>
-          </instructions>
         </configuration>
       </plugin>
       <plugin>

--- a/johnzon-websocket/src/main/java/module-info.java
+++ b/johnzon-websocket/src/main/java/module-info.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module org.apache.johnzon.websocket {
+    requires transitive org.apache.johnzon.mapper;
+
+    requires transitive jakarta.websocket.client;
+    requires transitive jakarta.websocket;
+    requires transitive jakarta.servlet;
+    requires transitive jakarta.json;
+    requires transitive jakarta.json.bind;
+
+    exports org.apache.johnzon.websocket.jsonb;
+    exports org.apache.johnzon.websocket.jsr;
+    exports org.apache.johnzon.websocket.mapper;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <project.build.outputTimestamp>10</project.build.outputTimestamp>
 
     <jakarta-jsonp-api.version>2.1.1</jakarta-jsonp-api.version>
     <jakarta-jsonb-api.version>3.0.0</jakarta-jsonb-api.version>
@@ -73,6 +72,33 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>jakarta.annotation</groupId>
+        <artifactId>jakarta.annotation-api</artifactId>
+        <version>2.1.1</version>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.persistence</groupId>
+        <artifactId>jakarta.persistence-api</artifactId>
+        <version>3.1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.transaction</groupId>
+        <artifactId>jakarta.transaction-api</artifactId>
+        <version>2.0.1</version>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.interceptor</groupId>
+        <artifactId>jakarta.interceptor-api</artifactId>
+        <version>2.1.0</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.inject</groupId>
+        <artifactId>jakarta.inject-api</artifactId>
+        <version>2.0.1</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
         <groupId>jakarta.json</groupId>
         <artifactId>jakarta.json-api</artifactId>
         <version>${jakarta-jsonp-api.version}</version>
@@ -83,6 +109,16 @@
         <artifactId>jakarta.json.bind-api</artifactId>
         <version>${jakarta-jsonb-api.version}</version>
         <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.ws.rs</groupId>
+        <artifactId>jakarta.ws.rs-api</artifactId>
+        <version>3.1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.enterprise</groupId>
+        <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        <version>4.0.1</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -113,32 +149,32 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.10.1</version>
+          <version>3.11.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.4.1</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-report-plugin</artifactId>
-          <version>3.0.0-M7</version>
+          <version>3.1.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -148,7 +184,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>3.0.0-M6</version>
+          <version>3.0.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -164,17 +200,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
-          <version>3.19.0</version>
+          <version>3.21.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.4.1</version>
+          <version>3.4.5</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.14.2</version>
+          <version>2.16.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -210,6 +246,8 @@
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
           <parameters>true</parameters>
+          <!-- disable JPMS when compiling test sources -->
+          <useModulePath>false</useModulePath>
         </configuration>
       </plugin>
 
@@ -415,7 +453,7 @@
               <goal>jar</goal>
             </goals>
             <configuration>
-              <show>private</show>
+              <show>protected</show>
               <detectJavaApiLink>false</detectJavaApiLink>
               <detectLinks>false</detectLinks>
               <detectOfflineLinks>false</detectOfflineLinks>
@@ -432,6 +470,7 @@
         <configuration>
           <argLine>${surefire.jvm.params}</argLine>
           <trimStackTrace>false</trimStackTrace>
+          <useModulePath>false</useModulePath>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
This is a follow up to #99 which merely configured _Automatic-Module-Name_

- Updated a few maven plugins
- Add module-info.java to all sub-projects that makes sense to do so
- Remove _Automatic-Module-Name_ in all sub-projects that now have module-info.java
- Also added a README.md