### PR TITLE
Fix NumberFormatCustomizationTest when running on JDK 13+

### DIFF
--- a/tck/jsonb/pom.xml
+++ b/tck/jsonb/pom.xml
@@ -138,8 +138,12 @@
           <systemProperties>
             <signature.sigTestClasspath>${project.build.outputDirectory}</signature.sigTestClasspath>
 
+            <!-- don't serialize BigDecimal/BigInteger as strings. Usually enabled by default in johnzon, see https://github.com/jakartaee/jsonb-api/issues/187 -->
             <johnzon.use-bigdecimal-stringadapter>false</johnzon.use-bigdecimal-stringadapter>
             <johnzon.use-biginteger-stringadapter>false</johnzon.use-biginteger-stringadapter>
+
+            <!-- needed to pass JSON-B 3 TCKs on jdk 13+, see https://github.com/jakartaee/jsonb-api/issues/272 -->
+            <java.locale.providers>COMPAT</java.locale.providers>
           </systemProperties>
           <argLine>-Duser.language=en -Duser.region=US</argLine>
         </configuration>


### PR DESCRIPTION
Going for some low hanging fruit here, simple configuration change that "fixes" two NumberFormatCustomizationTest tests when running on JDK 13+ (see https://github.com/jakartaee/jsonb-api/issues/272)

Also quickly documented on the system properties introduced in https://github.com/apache/johnzon/pull/103

This brings failing jsonb TCK tests down from:
```
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   SerializersCustomizationCDITest.testCDISupport:110 Failed to correctly unmarshall complex type hierarchy using a serializer configured using JsonbTypeSerializer annotation and a deserializer with a CDI managed field configured using JsonbTypeDeserializer annotation.
Expected: is <ee.jakarta.tck.json.bind.cdi.customizedmapping.serializers.model.AnimalShelterWithInjectedSerializer@672037ff>
     but: was <ee.jakarta.tck.json.bind.cdi.customizedmapping.serializers.model.AnimalShelterWithInjectedSerializer@1>
[ERROR]   InstantiationCustomizationTest.testJsonbDeserializerOnCreatorParameter:221 JsonbDeserializer on the JsonbCreator parameter was not executed.
Expected: is "Test String Deserialized"
     but: was "Test String"
[ERROR]   NumberFormatCustomizationTest.testNumberFormatField:112 Failed to correctly customize number format during marshalling using JsonbNumberFormat annotation on field.
Expected: a string matching the pattern '\{\s*"instance"\s*:\s*"123\u00a0456,789"\s*\}'
     but: was "{\"instance\":\"123 456,789\"}"
[ERROR]   ClassesMappingTest.testPrivateAccessorsPublicField:302 Failed to ignore setting public value using private setter.
Expected: is "Test String"
     but: was "New Test String"
[ERROR] Errors: 
[ERROR]   OptionalCreatorParametersTest.testOptionalTypesDefaultValues:98 » Jsonb Option...
[ERROR]   OptionalCreatorParametersTest.testOptionalTypesInCreator:113 » Jsonb OptionalT...
[ERROR]   OptionalCreatorParametersTest.testPrimitiveTypesDefaultValues:77 » Jsonb Primi...
[ERROR]   NumberFormatCustomizationTest.testNumberFormatAccessors:138 » Jsonb AccessorCu...
[ERROR]   AnnotationTypeInfoTest.testCreatorDeserialization:83 » IllegalArgument Invalid...
[ERROR]   JSONBSigTest.signatureTest:280 Fault JSONBSigTest.signatureTest() failed!, dif...
[INFO] 
[ERROR] Tests run: 295, Failures: 4, Errors: 6, Skipped: 5
```

to:
```
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   SerializersCustomizationCDITest.testCDISupport:110 Failed to correctly unmarshall complex type hierarchy using a serializer configured using JsonbTypeSerializer annotation and a deserializer with a CDI managed field configured using JsonbTypeDeserializer annotation.
Expected: is <ee.jakarta.tck.json.bind.cdi.customizedmapping.serializers.model.AnimalShelterWithInjectedSerializer@672037ff>
     but: was <ee.jakarta.tck.json.bind.cdi.customizedmapping.serializers.model.AnimalShelterWithInjectedSerializer@1>
[ERROR]   InstantiationCustomizationTest.testJsonbDeserializerOnCreatorParameter:221 JsonbDeserializer on the JsonbCreator parameter was not executed.
Expected: is "Test String Deserialized"
     but: was "Test String"
[ERROR]   ClassesMappingTest.testPrivateAccessorsPublicField:302 Failed to ignore setting public value using private setter.
Expected: is "Test String"
     but: was "New Test String"
[ERROR] Errors: 
[ERROR]   OptionalCreatorParametersTest.testOptionalTypesDefaultValues:98 » Jsonb Option...
[ERROR]   OptionalCreatorParametersTest.testOptionalTypesInCreator:113 » Jsonb OptionalT...
[ERROR]   OptionalCreatorParametersTest.testPrimitiveTypesDefaultValues:77 » Jsonb Primi...
[ERROR]   AnnotationTypeInfoTest.testCreatorDeserialization:83 » IllegalArgument Invalid...
[ERROR]   JSONBSigTest.signatureTest:280 Fault JSONBSigTest.signatureTest() failed!, dif...
[INFO] 
[ERROR] Tests run: 295, Failures: 3, Errors: 5, Skipped: 5
```
