### PR TITLE
Fix pluggability and SigTests TCKs

### DIFF
--- a/tck/jsonb/pom.xml
+++ b/tck/jsonb/pom.xml
@@ -77,13 +77,12 @@
   </dependencies>
 
   <build>
-    <testResources>
-      <testResource>
-        <directory>src/test/resources</directory>
-        <filtering>true</filtering>
-      </testResource>
-    </testResources>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
@@ -94,16 +93,10 @@
           <dependenciesToScan>
             <dependency>jakarta.json.bind:jakarta.json.bind-tck</dependency>
           </dependenciesToScan>
-          <includes>
-            <include>ee.jakarta.tck.json.bind.**</include>
-          </includes>
-          <!--
-          <excludes>
-            <exclude>**/JSONBSigTest</exclude>
-          </excludes>
-          -->
+
           <systemProperties>
-            <signature.sigTestClasspath>${project.build.outputDirectory}</signature.sigTestClasspath>
+            <jimage.dir>${project.build.directory}/jimage</jimage.dir>
+            <signature.sigTestClasspath>${project.build.directory}/signaturedirectory/jakarta.json.bind-api.jar:${project.build.directory}/jimage/java.base:${project.build.directory}/jimage/java.rmi:${project.build.directory}/jimage/java.sql:${project.build.directory}/jimage/java.naming</signature.sigTestClasspath>
 
             <!-- don't serialize BigDecimal/BigInteger as strings. Usually enabled by default in johnzon, see https://github.com/jakartaee/jsonb-api/issues/187 -->
             <johnzon.use-bigdecimal-stringadapter>false</johnzon.use-bigdecimal-stringadapter>
@@ -117,6 +110,4 @@
       </plugin>
     </plugins>
   </build>
-
-
 </project>

--- a/tck/jsonp/pom.xml
+++ b/tck/jsonp/pom.xml
@@ -34,11 +34,6 @@
       <groupId>jakarta.json</groupId>
       <artifactId>jakarta.json-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.apache.johnzon</groupId>
-      <artifactId>johnzon-core</artifactId>
-      <version>${project.version}</version>
-    </dependency>
 
     <dependency>
       <groupId>jakarta.json</groupId>
@@ -51,6 +46,12 @@
       <artifactId>jakarta.json-tck-tests-pluggability</artifactId>
       <version>2.1.1</version>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.johnzon</groupId>
+      <artifactId>johnzon-core</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -87,27 +88,58 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M7</version>
+        <version>${surefire.version}</version>
         <configuration>
           <reuseForks>false</reuseForks>
           <forkCount>1</forkCount>
-          <dependenciesToScan>
-            <dependency>jakarta.json:jakarta.json-tck-tests</dependency>
-            <dependency>jakarta.json:jakarta.json-tck-tests-pluggability</dependency>
-          </dependenciesToScan>
-          <includes>
-            <include>ee.jakarta.tck.jsonp.**</include>
-          </includes>
-          <!--
-          <excludes>
-            <exclude>**/JSONPSigTest</exclude>
-          </excludes>
-          -->
-          <systemProperties>
-            <signature.sigTestClasspath>${project.build.outputDirectory}</signature.sigTestClasspath>
-          </systemProperties>
         </configuration>
+
+        <!-- Pluggability tests need to be run separately from normal TCKs as they bring their
+             own JsonProvider implementation which would break other TCK tests -->
+        <executions>
+          <execution>
+            <id>tck-pluggability</id>
+
+            <goals>
+              <goal>test</goal>
+            </goals>
+
+            <configuration>
+              <dependenciesToScan>jakarta.json:jakarta.json-tck-tests-pluggability</dependenciesToScan>
+
+              <classpathDependencyExcludes>
+                <classpathDependencyExclude>jakarta.json:jakarta.json-tck-tests</classpathDependencyExclude>
+              </classpathDependencyExcludes>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>tck</id>
+
+            <goals>
+              <goal>test</goal>
+            </goals>
+
+            <configuration>
+              <dependenciesToScan>jakarta.json:jakarta.json-tck-tests</dependenciesToScan>
+
+              <systemProperties>
+                <jimage.dir>${project.build.directory}/jimage</jimage.dir>
+                <signature.sigTestClasspath>${project.build.directory}/signaturedirectory/jakarta.json-api.jar:${project.build.directory}/jimage/java.base:${project.build.directory}/jimage/java.rmi:${project.build.directory}/jimage/java.sql:${project.build.directory}/jimage/java.naming</signature.sigTestClasspath>
+              </systemProperties>
+
+              <classpathDependencyExcludes>
+                <classpathDependencyExclude>jakarta.json:jakarta.json-tck-tests-pluggability</classpathDependencyExclude>
+              </classpathDependencyExcludes>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -34,4 +34,49 @@
     <module>jsonp</module>
   </modules>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.2.0</version>
+          <executions>
+            <execution>
+              <id>copy</id>
+              <phase>generate-test-resources</phase>
+              <goals>
+                <goal>copy</goal>
+              </goals>
+
+              <configuration>
+                <artifactItems>
+                  <artifactItem>
+                    <groupId>jakarta.json</groupId>
+                    <artifactId>jakarta.json-api</artifactId>
+                    <version>${jakarta-jsonp-api.version}</version>
+                    <type>jar</type>
+                    <overWrite>true</overWrite>
+                    <outputDirectory>${project.build.directory}/signaturedirectory</outputDirectory>
+                    <destFileName>jakarta.json-api.jar</destFileName>
+                  </artifactItem>
+
+                  <artifactItem>
+                    <groupId>jakarta.json.bind</groupId>
+                    <artifactId>jakarta.json.bind-api</artifactId>
+                    <version>${jakarta-jsonb-api.version}</version>
+                    <type>jar</type>
+                    <overWrite>true</overWrite>
+                    <outputDirectory>${project.build.directory}/signaturedirectory</outputDirectory>
+                    <destFileName>jakarta.json.bind-api.jar</destFileName>
+                  </artifactItem>
+                </artifactItems>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>


### PR DESCRIPTION
This is the counterpart to #110 and fixes all remaining TCK tests for JSON-P (pluggability and JSONPSigTest) and also fixes JSONBSigTest for JSON-B

Took orientation from how [JSON-P](https://github.com/jakartaee/jsonp-api/tree/2.1.1-tck/tck/tck-dist-eftl/src/main/bin) and [JSON-B](https://github.com/jakartaee/jsonb-api/tree/3.0.0-tck/tck-dist/src/main/bin) TCKs are apparently supposed to be run. Feel free to suggest changes as I've never dealt with something like this before