### PR TITLE
Site updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.outputTimestamp>1698151225</project.build.outputTimestamp>
+    <maven.compiler.release>11</maven.compiler.release>
 
     <jakarta-jsonp-api.version>2.1.1</jakarta-jsonp-api.version>
     <jakarta-jsonb-api.version>3.0.0</jakarta-jsonb-api.version>
@@ -205,7 +206,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <release>11</release>
           <encoding>${project.build.sourceEncoding}</encoding>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>

--- a/src/site/markdown/download.md
+++ b/src/site/markdown/download.md
@@ -28,7 +28,7 @@ should be addressed to the [mailing list](http://johnzon.apache.org/mail-lists.h
 
 ## KEYS for verifying Apache releases
 
-Please use the Johnzon [KEYS](https://www.apache.org/dist/johnzon/KEYS) file to validate our releases.
+Please use the Johnzon [KEYS](https://www.apache.org/dyn/closer.lua/johnzon/KEYS) file to validate our releases.
 Read more about [how we sign Apache Releases](http://www.apache.org/info/verification.html)
 
 
@@ -49,13 +49,25 @@ We are still actively working on passing the TCK but so far most of the implemen
 
 Apache Johnzon 1.2.x implements the JSON-P 1.1 and JSON-B 1.0 specifications which on a level of JavaEE 8.
 
+
+#### Binaries
+The binary distribution contains all Johnzon modules.
+* [apache-johnzon-1.2.21-bin.zip](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.2.21/apache-johnzon-1.2.21-bin.zip)
+* [apache-johnzon-1.2.21-bin.zip.sha256](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.2.21/apache-johnzon-1.2.21-bin.zip.sha256)
+* [apache-johnzon-1.2.21-bin.zip.asc](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.2.21/apache-johnzon-1.2.21-bin.zip.asc)
+* [apache-johnzon-1.2.21-bin.tar.gz](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.2.21/apache-johnzon-1.2.21-bin.tar.gz)
+* [apache-johnzon-1.2.21-bin.tar.gz.sha256](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.2.21/apache-johnzon-1.2.21-bin.tar.gz.sha256)
+* [apache-johnzon-1.2.21-bin.tar.gz.asc](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.2.21/apache-johnzon-1.2.21-bin.tar.gz.asc)
+
+
 #### Source
 Should you want to build any of the above binaries, this source bundle is the right one and covers them all.
-
-* [johnzon-1.2.20-source-release.zip](https://www.apache.org/dyn/closer.lua/1.2.20/johnzon-1.2.20-source-release.zip)
-* [johnzon-1.2.20-source-release.zip.sha512](https://www.apache.org/dist/johnzon/1.2.20/johnzon-1.2.20-source-release.zip.sha512)
-* [johnzon-1.2.20-source-release.zip.asc](https://www.apache.org/dist/johnzon/1.2.20/johnzon-1.2.20-source-release.zip.asc)
-
+* [apache-johnzon-1.2.21-src.zip](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.2.21/apache-johnzon-1.2.21-src.zip)
+* [apache-johnzon-1.2.21-src.zip.sha512](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.2.21/apache-johnzon-1.2.21-src.zip.sha512)
+* [apache-johnzon-1.2.21-src.zip.asc](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.2.21/apache-johnzon-1.2.21-src.zip.asc)
+* [apache-johnzon-1.2.21-src.tar.gz](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.2.21/apache-johnzon-1.2.21-src.tar.gz)
+* [apache-johnzon-1.2.21-src.tar.gz.sha512](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.2.21/apache-johnzon-1.2.21-src.tar.gz.sha512)
+* [apache-johnzon-1.2.21-src.tar.gz.asc](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.2.21/apache-johnzon-1.2.21-src.tar.gz.asc)
 
 ## Johnzon-1.0.x
 
@@ -66,16 +78,21 @@ This corresponds to JavaEE 7 level.
 The binary distribution contains all Johnzon modules.
 
 * [apache-johnzon-1.0.2-bin.zip](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.0.2/apache-johnzon-1.0.2-bin.zip)
-* [apache-johnzon-1.0.2-bin.zip.sha256](https://www.apache.org/dist/johnzon/johnzon-1.0.2/apache-johnzon-1.0.2-bin.zip.sha256)
-* [apache-johnzon-1.0.2-bin.zip.asc](https://www.apache.org/dist/johnzon/johnzon-1.0.2/apache-johnzon-1.0.2-bin.zip.asc)
+* [apache-johnzon-1.0.2-bin.zip.sha256](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.0.2/apache-johnzon-1.0.2-bin.zip.sha256)
+* [apache-johnzon-1.0.2-bin.zip.asc](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.0.2/apache-johnzon-1.0.2-bin.zip.asc)
+* [apache-johnzon-1.0.2-bin.tar.gz](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.0.2/apache-johnzon-1.0.2-bin.tar.gz)
+* [apache-johnzon-1.0.2-bin.tar.gz.sha256](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.0.2/apache-johnzon-1.0.2-bin.tar.gz.sha256)
+* [apache-johnzon-1.0.2-bin.tar.gz.asc](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.0.2/apache-johnzon-1.0.2-bin.tar.gz.asc)
 
 #### Source
 Should you want to build any of the above binaries, this source bundle is the right one and covers them all.
 
-* [johnzon-1.0.2-source-release.zip](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.0.2/apache-johnzon-1.0.2-source-release.zip)
-* [johnzon-1.0.2-source-release.zip.sha256](https://www.apache.org/dist/johnzon/johnzon-1.0.2/apache-johnzon-1.0.2-source-release.zip.sha256)
-* [johnzon-1.0.2-source-release.zip.asc](https://www.apache.org/dist/johnzon/johnzon-1.0.2/apache-johnzon-1.0.2-source-release.zip.asc)
-
+* [apache-johnzon-1.0.2-src.zip](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.0.2/apache-johnzon-1.0.2-src.zip)
+* [apache-johnzon-1.0.2-src.zip.sha256](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.0.2/apache-johnzon-1.0.2-src.zip.sha256)
+* [apache-johnzon-1.0.2-src.zip.asc](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.0.2/apache-johnzon-1.0.2-src.zip.asc)
+* [apache-johnzon-1.0.2-src.tar.gz](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.0.2/apache-johnzon-1.0.2-src.tar.gz)
+* [apache-johnzon-1.0.2-src.tar.gz.sha256](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.0.2/apache-johnzon-1.0.2-src.tar.gz.sha256)
+* [apache-johnzon-1.0.2-src.tar.gz.asc](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.0.2/apache-johnzon-1.0.2-src.tar.gz.asc)
 -------
 
 ### Maven Dependencies

--- a/src/site/markdown/download.md
+++ b/src/site/markdown/download.md
@@ -36,28 +36,30 @@ Read more about [how we sign Apache Releases](http://www.apache.org/info/verific
 
 ## Johnzon-2.0.x
 
-Apache Johnzon 2.0.x implements the JSON-P 2.1 and JSON-B 3.0 specifications which on a level of JavaEE 10. This version is not backward compatible due to the namespace change from `javax` to `jakarta`. 
+Apache Johnzon 2.0.x implements the JSON-P 2.1 and JSON-B 3.0 specifications which are in line with the Jakarta EE Platform 10. This version is not backward compatible due to the namespace change from `javax` to `jakarta`. 
 Apache Johnzon does not implement Jakarta EE 9 per se, because there was no change in terms of APIs except the namespace change. 
 So we decided to use Apache Johnzon 1.2.x bellow and publish a Jakarta compatible version using bytecode transformation. All artifacts can be used with the classifier `jakarta`.
 
-#### Source
+#### Binaries
+Binaries should be obtained from [maven central](https://repo1.maven.org/maven2/org/apache/johnzon/).
 
-This version is currently only available as snapshot. 
-We are still actively working on passing the TCK but so far most of the implementation is ready.
+
+#### Source
+Should you want to build any of the above binaries, this source bundle is the right one and covers them all.
+* [apache-johnzon-2.0.0-src.zip](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-2.0.0/apache-johnzon-2.0.0-src.zip)
+* [apache-johnzon-2.0.0-src.zip.sha512](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-2.0.0/apache-johnzon-2.0.0-src.zip.sha512)
+* [apache-johnzon-2.0.0-src.zip.asc](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-2.0.0/apache-johnzon-2.0.0-src.zip.asc)
+* [apache-johnzon-2.0.0-src.tar.gz](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-2.0.0/apache-johnzon-2.0.0-src.tar.gz)
+* [apache-johnzon-2.0.0-src.tar.gz.sha512](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-2.0.0/apache-johnzon-2.0.0-src.tar.gz.sha512)
+* [apache-johnzon-2.0.0-src.tar.gz.asc](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-2.0.0/apache-johnzon-2.0.0-src.tar.gz.asc)
 
 ## Johnzon-1.2.x
 
-Apache Johnzon 1.2.x implements the JSON-P 1.1 and JSON-B 1.0 specifications which on a level of JavaEE 8.
+Apache Johnzon 1.2.x implements the JSON-P 1.1 and JSON-B 1.0 specifications which are in line with the Jakarta EE Platform 8.
 
 
 #### Binaries
-The binary distribution contains all Johnzon modules.
-* [apache-johnzon-1.2.21-bin.zip](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.2.21/apache-johnzon-1.2.21-bin.zip)
-* [apache-johnzon-1.2.21-bin.zip.sha256](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.2.21/apache-johnzon-1.2.21-bin.zip.sha256)
-* [apache-johnzon-1.2.21-bin.zip.asc](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.2.21/apache-johnzon-1.2.21-bin.zip.asc)
-* [apache-johnzon-1.2.21-bin.tar.gz](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.2.21/apache-johnzon-1.2.21-bin.tar.gz)
-* [apache-johnzon-1.2.21-bin.tar.gz.sha256](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.2.21/apache-johnzon-1.2.21-bin.tar.gz.sha256)
-* [apache-johnzon-1.2.21-bin.tar.gz.asc](https://www.apache.org/dyn/closer.lua/johnzon/johnzon-1.2.21/apache-johnzon-1.2.21-bin.tar.gz.asc)
+Binaries should be obtained from [maven central](https://repo1.maven.org/maven2/org/apache/johnzon/).
 
 
 #### Source

--- a/src/site/markdown/download.md
+++ b/src/site/markdown/download.md
@@ -41,7 +41,7 @@ Apache Johnzon does not implement Jakarta EE 9 per se, because there was no chan
 So we decided to use Apache Johnzon 1.2.x bellow and publish a Jakarta compatible version using bytecode transformation. All artifacts can be used with the classifier `jakarta`.
 
 #### Binaries
-Binaries should be obtained from [maven central](https://repo1.maven.org/maven2/org/apache/johnzon/).
+Binaries should be obtained from [maven central](https://repo.maven.apache.org/maven2/org/apache/johnzon/).
 
 
 #### Source
@@ -59,7 +59,7 @@ Apache Johnzon 1.2.x implements the JSON-P 1.1 and JSON-B 1.0 specifications whi
 
 
 #### Binaries
-Binaries should be obtained from [maven central](https://repo1.maven.org/maven2/org/apache/johnzon/).
+Binaries should be obtained from [maven central](https://repo.maven.apache.org/maven2/org/apache/johnzon/).
 
 
 #### Source

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -65,6 +65,8 @@ The generator factory supports the standard properties (pretty one for example) 
 
 ### JSON-P Strict Compliance (stable)
 
+**This has been removed with Johnzon 2.0.x, johnzon-core is now JSON-P compliant by default.**
+
 <pre class="prettyprint linenums"><![CDATA[
 <dependency>
   <groupId>org.apache.johnzon</groupId>
@@ -353,6 +355,8 @@ JsonbConfig specific properties:
 * johnzon.accessMode: custom access mode, note that it can disable some JSON-B feature (annotations support).
 * johnzon.accessModeDelegate: delegate access mode used by JsonbAccessModel. Enables to enrich default access mode.
 * johnzon.failOnMissingCreatorValues: should the mapping fail when a `@JsonbCreator` misses some values.
+* johnzon.use-biginteger-stringadapter: Wether or not `BigInteger` is mapped as a string. `true` by default, set to `false` to ensure strict JSON-B 3 compliance
+* johnzon.use-bigdecimal-stringadapter: Wether or not `BigDecimal` is mapped as a string. `true` by default, set to `false` to ensure strict JSON-B 3 compliance
 
 TIP: more in JohnzonBuilder class.
 

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -52,6 +52,9 @@ You'll surely want to add the API as dependency too:
 </dependency>
 ]]></pre>
 
+**Please note**: The jakarta JSON-P API jar has [hardcoded parsson](https://github.com/jakartaee/jsonp-api/blob/2.1.2/api/src/main/java/jakarta/json/spi/JsonProvider.java#L74-L79) as the default JSON-P implementation.
+This might cause unintended behaviour in cases where standard Java service loading is not possible.
+
 #### Johnzon Factory Configurations
 
 ##### JsonGeneratorFactory

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -24,7 +24,7 @@ for this specification like an Object mapper, some JAX-RS providers and a WebSoc
 ## Status
 
 Apache Johnzon is a Top Level Project at the Apache Software Foundation (ASF).
-It fully implements the JSON-P_1.1 (JSR-353) and JSON-B_1.0 (JSR-367) specifications.
+It fully implements the [JSON-P 2.1](https://jakarta.ee/specifications/jsonp/2.1/) and [JSON-B 3.0](https://jakarta.ee/specifications/jsonb/3.0/) specifications.
 
 ## Get started
 
@@ -40,14 +40,14 @@ Johnzon comes with four main modules.
 </dependency>
 ]]></pre>
 
-This is the implementation of the JSON-P 1.1 specification. 
+This is the implementation of the JSON-P 2.1 specification. 
 You'll surely want to add the API as dependency too:
 
 <pre class="prettyprint linenums"><![CDATA[
 <dependency>
-  <groupId>org.apache.geronimo.specs</groupId>
-  <artifactId>geronimo-json_1.1_spec</artifactId>
-  <version>${jsonspecversion}</version>
+  <groupId>jakarta.json</groupId>
+  <artifactId>jakarta.json-api</artifactId>
+  <version>2.1.2</version>
   <scope>provided</scope> <!-- or compile if your environment doesn't provide it -->
 </dependency>
 ]]></pre>
@@ -328,7 +328,7 @@ TomEE uses by default Johnzon as JAX-RS provider for versions 7.x. If you want h
 Note: as you can see you mainly just need to define a service with the id johnzon (same as in openejb-jar.xml)
 and you can reference other instances using $id for services and @id for resources.
 
-### JSON-B (JSON-B 1.0 compliant)
+### JSON-B (JSON-B 3.0 compliant)
 
 Johnzon provides a module johnzon-jsonb implementing JSON-B standard based on Johnzon Mapper.
 

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -355,8 +355,8 @@ JsonbConfig specific properties:
 * johnzon.accessMode: custom access mode, note that it can disable some JSON-B feature (annotations support).
 * johnzon.accessModeDelegate: delegate access mode used by JsonbAccessModel. Enables to enrich default access mode.
 * johnzon.failOnMissingCreatorValues: should the mapping fail when a `@JsonbCreator` misses some values.
-* johnzon.use-biginteger-stringadapter: Wether or not `BigInteger` is mapped as a string. `true` by default, set to `false` to ensure strict JSON-B 3 compliance
-* johnzon.use-bigdecimal-stringadapter: Wether or not `BigDecimal` is mapped as a string. `true` by default, set to `false` to ensure strict JSON-B 3 compliance
+* johnzon.use-biginteger-stringadapter: Whether or not `BigInteger` is mapped as a string. `true` by default, set to `false` to ensure strict JSON-B 3 compliance
+* johnzon.use-bigdecimal-stringadapter: Whether or not `BigDecimal` is mapped as a string. `true` by default, set to `false` to ensure strict JSON-B 3 compliance
 
 TIP: more in JohnzonBuilder class.
 

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -74,9 +74,9 @@
       <item name="Home" href="/index.html"/>
       <item name="Download" href="./download.html"/>
       <item name="Javadoc" href="/apidocs/index.html"/>
-      <item name="Source Code" href="/source-repository.html"/>
+      <item name="Source Code" href="/scm.html"/>
       <item name="Changelog" href="/changelog.html"/>
-      <item name="Mailing Lists" href="/mail-lists.html"/>
+      <item name="Mailing Lists" href="/mailing-lists.html"/>
     </menu>
     
     <menu name="Old Releases">


### PR DESCRIPTION
Fixes a few things I noticed while looking at the current site like broken links, javadoc not generating anymore, outdated download links, etc

Also Updates the site for JSON-P 2.1/JSON-B 3.0, documents properties I added in #103 and the removal of johnzon-jsonp-strict