### PR TITLE
Add nashorn engine dependency in compiled scope for Java 15+

### DIFF
--- a/johnzon-jsonschema/pom.xml
+++ b/johnzon-jsonschema/pom.xml
@@ -77,7 +77,6 @@
             <groupId>org.openjdk.nashorn</groupId>
             <artifactId>nashorn-core</artifactId>
             <version>15.3</version>
-            <scope>test</scope>
           </dependency>
         </dependencies>
     </profile>


### PR DESCRIPTION
When trying to bump my application to Java 17, I faced issues with johnzon json-schema module.

As explained here https://stackoverflow.com/questions/71481562/use-javascript-scripting-engine-in-java-17 the nashorn javascript engine is removed starting jdk 15.

Here is the error I faced with JDK 17 :

`java.lang.NullPointerException: Cannot invoke "javax.script.ScriptEngine.createBindings()" because "org.apache.johnzon.jsonschema.regex.JavascriptRegex.ENGINE" is null`

Adding nashorn dependency in my application fixes the issue, but it is tricky to discover what gone wrong, so I suggest taking care of it here.

See here for the NullPointerException origin : https://github.com/apache/johnzon/blob/885cec0ef9484c3666c82315826143045f1c492a/johnzon-jsonschema/src/main/java/org/apache/johnzon/jsonschema/regex/JavascriptRegex.java#L32