### PR TITLE
Guard DateConverter against null

### DIFF
--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/DateConverter.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/converter/DateConverter.java
@@ -30,6 +30,10 @@ public class DateConverter implements Converter<Date> {
     private final ThreadLocal<DateFormat> format;
 
     public DateConverter(final String pattern) {
+        if (pattern == null) {
+            throw new IllegalArgumentException("pattern must not be null");
+        }
+
         format = new ThreadLocal<DateFormat>() {
             @Override
             protected DateFormat initialValue() {

--- a/johnzon-mapper/src/test/java/org/apache/johnzon/mapper/converter/DateConverterTest.java
+++ b/johnzon-mapper/src/test/java/org/apache/johnzon/mapper/converter/DateConverterTest.java
@@ -1,0 +1,15 @@
+package org.apache.johnzon.mapper.converter;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
+
+public class DateConverterTest {
+    @Test
+    public void rejectNullPattern() {
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            final String pattern = null;
+            new DateConverter(pattern);
+        });
+    }
+}


### PR DESCRIPTION
When `null` is passed to the `DateConverter` constructor, NullPointerException will eventually be thrown.
However, since the constructor is lazily evaluated, this is not thrown until much later, leading to difficult debugging.
This commit implements a guard against `null` input, throwing an IllegalArgumentException.