### PR TITLE
[JOHNZON-402] Reworked scanning for @JsonbTypeInfo annotations

### DIFF
--- a/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/JsonbMappings.java
+++ b/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/JsonbMappings.java
@@ -49,7 +49,6 @@ public class JsonbMappings extends Mappings {
         }
 
         polymorphismHandler.validateJsonbPolymorphismAnnotations(original.clazz);
-        polymorphismHandler.populateTypeInfoCache(original.clazz);
         return new ClassMapping(
                 original.clazz, original.factory, original.getters, original.setters,
                 original.adapter, original.reader, original.writer, original.anyGetter,

--- a/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/polymorphism/JsonbPolymorphismTypeInfo.java
+++ b/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/polymorphism/JsonbPolymorphismTypeInfo.java
@@ -20,14 +20,30 @@ package org.apache.johnzon.jsonb.polymorphism;
 
 import jakarta.json.bind.annotation.JsonbSubtype;
 import jakarta.json.bind.annotation.JsonbTypeInfo;
+
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class JsonbPolymorphismTypeInfo {
+    private final List<JsonbPolymorphismTypeInfo> parents;
+    private final Class<?> clazz;
+
     private final String typeKey;
     private final Map<String, Class<?>> aliases;
 
-    protected JsonbPolymorphismTypeInfo(JsonbTypeInfo annotation) {
+    protected JsonbPolymorphismTypeInfo(Class<?> clazz, JsonbTypeInfo annotation) {
+        this.parents = new ArrayList<>();
+        this.clazz = clazz;
+
+        if (annotation == null) {
+            this.typeKey = null;
+            this.aliases = null;
+
+            return;
+        }
+
         this.typeKey = annotation.key();
 
         aliases = new HashMap<>();
@@ -36,11 +52,31 @@ public class JsonbPolymorphismTypeInfo {
         }
     }
 
+    public boolean hasSubtypeInformation() {
+        return typeKey != null;
+    }
+
     public String getTypeKey() {
         return typeKey;
     }
 
     public Map<String, Class<?>> getAliases() {
         return aliases;
+    }
+
+    public Class<?> getClazz() {
+        return clazz;
+    }
+
+    public List<JsonbPolymorphismTypeInfo> getParents() {
+        return parents;
+    }
+
+    public JsonbPolymorphismTypeInfo getFirstParent() {
+        if (parents.isEmpty()) {
+            return null;
+        }
+
+        return parents.get(0);
     }
 }

--- a/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/polymorphism/JsonbPolymorphismTest.java
+++ b/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/polymorphism/JsonbPolymorphismTest.java
@@ -136,4 +136,17 @@ public class JsonbPolymorphismTest {
             return localDate;
         }
     }
+
+    @Test
+    public void typeInfoNotOnDirectParent() {
+        ConcreteSomething something = new ConcreteSomething();
+        assertEquals("{\"@type\":\"concrete\"}", jsonb.toJson(something));
+    }
+
+    @JsonbTypeInfo(
+            @JsonbSubtype(alias = "concrete", type = ConcreteSomething.class)
+    )
+    public static abstract class AbstractTopLevelSomething { }
+    public static abstract class AbstractMiddleLevelSomething extends AbstractTopLevelSomething { }
+    public static class ConcreteSomething extends AbstractMiddleLevelSomething { }
 }


### PR DESCRIPTION
This resolves [JOHNZON-402](https://issues.apache.org/jira/projects/JOHNZON/issues/JOHNZON-402)

TCKs still pass after this change, but the modules need their version to be changed from `2.0.0-SNAPSHOT` to `2.0.1-SNAPSHOT` (see #119)