### PR TITLE
reduce enum array allocation

### DIFF
--- a/johnzon-core/src/main/java/org/apache/johnzon/core/JsonStreamParserImpl.java
+++ b/johnzon-core/src/main/java/org/apache/johnzon/core/JsonStreamParserImpl.java
@@ -384,8 +384,8 @@ public class JsonStreamParserImpl extends JohnzonJsonParserImpl implements JsonC
 
     @Override
     public Event currentEvent() {
-        return previousEvent >= 0 && previousEvent < Event.values().length
-                ? Event.values()[previousEvent]
+        return previousEvent >= 0 && previousEvent < EVT_MAP.length
+                ? EVT_MAP[previousEvent]
                 : null;
     }
 


### PR DESCRIPTION
## Motivation

reduce enum array allocation

## Modifications

use cached enum .values() 


## Additional context

https://www.gamlor.info/wordpress/2017/08/javas-enum-values-hidden-allocations/
