### PR TITLE
Tolerate null @JsonbCreator values when adapters are used

### DIFF
--- a/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/AdapterTest.java
+++ b/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/AdapterTest.java
@@ -19,6 +19,8 @@ package org.apache.johnzon.jsonb;
  */
 
 
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbProperty;
 import org.junit.Test;
 
 import jakarta.json.Json;
@@ -39,6 +41,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -133,6 +136,39 @@ public class AdapterTest {
 
             final Foo2 read = jsonb.fromJson(toString, Foo2.class);
             assertEquals(foo.dummy.value, read.dummy.value);
+        }
+    }
+
+    @Test
+    public void adaptJsonWithCreator() throws Exception {
+        try (final Jsonb jsonb = JsonbBuilder.create()) {
+            final String json = "{\"value\":\"orange\", \"dummy\":\"2\"}";
+
+            final Foo3 foo3 = jsonb.fromJson(json, Foo3.class);
+            assertEquals("orange", foo3.value);
+            assertEquals(2, foo3.dummy.value);
+        }
+    }
+
+    @Test
+    public void adaptJsonWithCreatorNull() throws Exception {
+        try (final Jsonb jsonb = JsonbBuilder.create()) {
+            final String json = "{\"value\":\"orange\"}";
+
+            final Foo3 foo3 = jsonb.fromJson(json, Foo3.class);
+            assertEquals("orange", foo3.value);
+            assertNull( foo3.dummy);
+        }
+    }
+
+    @Test
+    public void adaptJsonWithFieldNull() throws Exception {
+        try (final Jsonb jsonb = JsonbBuilder.create()) {
+            final String json = "{\"value\":\"orange\"}";
+
+            final Foo4 foo4 = jsonb.fromJson(json, Foo4.class);
+            assertEquals("orange", foo4.value);
+            assertNull( foo4.dummy);
         }
     }
 
@@ -239,6 +275,26 @@ public class AdapterTest {
         }
     }
 
+    public static class Foo3 {
+        public String value;
+
+        @JsonbTypeAdapter(DummyAdapter.class)
+        public Dummy dummy;
+
+        @JsonbCreator
+        public Foo3(@JsonbProperty("dummy") @JsonbTypeAdapter(DummyAdapter.class) final Dummy dummy,
+                    @JsonbProperty("value") final String value) {
+            this.dummy = dummy;
+            this.value = value;
+        }
+    }
+
+    public static class Foo4 {
+        public String value;
+
+        @JsonbTypeAdapter(DummyAdapter.class)
+        public Dummy dummy;
+    }
 
     public static class Foo2 {
         @JsonbTypeAdapter(Dummy2Adapter.class)
@@ -391,4 +447,6 @@ public class AdapterTest {
         }
 
     }
+
+
 }

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MappingParserImpl.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MappingParserImpl.java
@@ -498,6 +498,10 @@ public class MappingParserImpl implements MappingParser {
             return converter.to(jsonValue);
         }
 
+        if (jsonValue == null) {
+            return getNullValue(targetType);
+        }
+
         if (JsonValue.ValueType.OBJECT == valueType) {
             if (JsonObject.class == key.getTo() || JsonStructure.class == key.getTo()) {
                 return converter.to(jsonValue.asJsonObject());
@@ -598,20 +602,7 @@ public class MappingParserImpl implements MappingParser {
                             final Type type, final Adapter itemConverter, final JsonPointerTracker jsonPointer,
                             final Type rootType) {
         if (jsonValue == null) {
-            if (OptionalInt.class == type) {
-                return OptionalInt.empty();
-            }
-            if (OptionalDouble.class == type) {
-                return OptionalDouble.empty();
-            }
-            if (OptionalLong.class == type) {
-                return OptionalLong.empty();
-            }
-            if (type instanceof ParameterizedType && Optional.class == ((ParameterizedType)type).getRawType()) {
-                return Optional.empty();
-            }
-
-            return null;
+            return getNullValue(type);
         }
 
         JsonValue.ValueType valueType = jsonValue.getValueType();
@@ -750,6 +741,23 @@ public class MappingParserImpl implements MappingParser {
         final String snippet = config.getSnippet().of(jsonValue);
         final String description = ExceptionMessages.description(valueType);
         throw new MapperException("Unable to parse " + description + " to " + type + ": " + snippet);
+    }
+
+    private static Object getNullValue(final Type type) {
+        if (OptionalInt.class == type) {
+            return OptionalInt.empty();
+        }
+        if (OptionalDouble.class == type) {
+            return OptionalDouble.empty();
+        }
+        if (OptionalLong.class == type) {
+            return OptionalLong.empty();
+        }
+        if (type instanceof ParameterizedType && Optional.class == ((ParameterizedType) type).getRawType()) {
+            return Optional.empty();
+        }
+
+        return null;
     }
 
     private Object buildArray(final Type type, final JsonArray jsonArray, final Adapter itemConverter,


### PR DESCRIPTION
When using Field injection, null (missing) json values are naturally tolerated.

When using Constructor inject, null (missing) json values are explicitly tolerated in `MappingParserImpl.toObject`.  However, if an adapter was specified,  `MappingParserImpl.convertTo` would throw a null pointer as it did not have the same code to deal with null values.